### PR TITLE
Fix a typo. "Big bag -> Big bang".

### DIFF
--- a/docs/pact_broker/can_i_deploy.md
+++ b/docs/pact_broker/can_i_deploy.md
@@ -53,7 +53,7 @@ Now, what happens when Foo gets another provider, Baz. Do we need to add `--pact
 
 ## Summary
 
-To stay safe while avoiding "big bag" deployments, add the following line before deploying:
+To stay safe while avoiding "big bang" deployments, add the following line before deploying:
 
 `$ pact-broker can-i-deploy --pacticipant PACTICIPANT --version VERSION --to STAGE`
 


### PR DESCRIPTION
### Context

I found this type while reading the documentation on https://docs.pact.io/pact_broker/can_i_deploy. This PR aims at fixing it.