### PR TITLE
Fix broken link on provider verification results page

### DIFF
--- a/website/docs/pact_broker/advanced_topics/provider_verification_results.md
+++ b/website/docs/pact_broker/advanced_topics/provider_verification_results.md
@@ -29,9 +29,9 @@ If your pact URL includes basic auth configurations for the pact broker, these w
 
 Earlier versions of the Pact libraries accepted a list of consumer version tags, and fetched each pact directly by tag. The more recent versions of the Pact libraries use a "pacts for verification" endpoint in the Pact Broker. It supports:
 
-* the [pending pacts](/pending) feature.
-* the [work in progress pacts](/wip) feature.
-* specifying the pacts to verify using [consumer version selectors](/consumer_version_selectors) rather than just a list of tags.
+* the [pending pacts](./pending_pacts) feature.
+* the [work in progress pacts](./wip_pacts) feature.
+* specifying the pacts to verify using [consumer version selectors](./consumer_version_selectors) rather than just a list of tags.
 * de-duplication of pact contents for faster verifications.
 
 To use these features:

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -201,7 +201,6 @@
       "pact_broker/overview",
       "getting_started/versioning_in_the_pact_broker",
       "pact_broker/publishing_and_retrieving_pacts",
-      "pact_broker/advanced_topics/provider_verification_results",
       "pact_broker/tags",
       {
         "type": "category",
@@ -236,6 +235,7 @@
           "pact_broker/pacticipant_version_numbers",
           "pact_broker/advanced_topics/see_changes_pact",
           "pact_broker/advanced_topics/provider_verification_badges",
+          "pact_broker/advanced_topics/provider_verification_results",
           "pact_broker/advanced_topics/pacticipant",
           "pact_broker/advanced_topics/pending_pacts",
           "pact_broker/advanced_topics/wip_pacts",


### PR DESCRIPTION
Move that advanced topic page to proper sidebar category and fix broken
link to consumer version selectors page.

https://docs.pact.io/pact_broker/advanced_topics/provider_verification_results

![Screenshot 2020-11-11 at 12 59 54](https://user-images.githubusercontent.com/2437969/98809511-f18af780-241d-11eb-926e-212db58a4e99.jpeg)
