### PR TITLE
fix: Update api_docs.md

### DIFF
--- a/website/docs/pact_broker/advanced_topics/api_docs.md
+++ b/website/docs/pact_broker/advanced_topics/api_docs.md
@@ -8,9 +8,9 @@ For an up-to-date list of all the API resources, view the actual code [here](htt
 
 _Key resources:_
 
-* [Publishing pacts](./api_docs/publish_pact)
-* [Publishing verification results](./api_docs/publish_verification_result)
-* [Webhooks](./api_docs/webhooks)
-* [Pacticipants](./api_docs/pacticipant)
-* [Pact diff](./api_docs/pact_diff)
+* [Publishing pacts](./publish_pact)
+* [Publishing verification results](./publish_verification_result)
+* [Webhooks](./webhooks)
+* [Pacticipants](./pacticipant)
+* [Pact diff](./pact_diff)
 

--- a/website/docs/pact_broker/advanced_topics/api_docs.md
+++ b/website/docs/pact_broker/advanced_topics/api_docs.md
@@ -4,7 +4,7 @@ title: API documentation
 
 This documentation and more can be found in the HAL browser \(`/hal-browser/browser.html`\) of any running pact broker. To view it, in the links section, click on the docs link \(the book icon\) next to the endpoint you wish to know about.
 
-For an up-to-date list of all the API resources, view the actual code [here](https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/api.rb). 
+For an up-to-date list of all the API resources, view the actual code [here](https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/api.rb).
 
 _Key resources:_
 

--- a/website/docs/pact_broker/advanced_topics/api_docs.md
+++ b/website/docs/pact_broker/advanced_topics/api_docs.md
@@ -4,7 +4,7 @@ title: API documentation
 
 This documentation and more can be found in the HAL browser \(`/hal-browser/browser.html`\) of any running pact broker. To view it, in the links section, click on the docs link \(the book icon\) next to the endpoint you wish to know about.
 
-For an up-to-date list of all the API resources, view the actual code [here](https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/api.rb).
+For an up-to-date list of all the API resources, view the actual code [here](https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/api.rb). 
 
 _Key resources:_
 


### PR DESCRIPTION
all of the links had "/api_docs/" repeated in the path (ex: "https://docs.pact.io/pact_broker/advanced_topics/api_docs/api_docs/pacticipant")  and resulted in a page not found error for all links under advanced topics