### PR TITLE
Fix broken link - Pact broker tags section

### DIFF
--- a/website/docs/pact_broker/tags.md
+++ b/website/docs/pact_broker/tags.md
@@ -152,7 +152,7 @@ _Remember:_ just because you're doing consumer driven contracts doesn't mean tha
 
 ## Ensuring backwards compatibility
 
-If you want to ensure your provider is compatible with both the head version of your consumer, and the production version, you can use pact tagging to achieve this. To read more about this idea, check out this [blog post](http://techblog.realestate.com.au/enter-the-pact-matrix-or-how-to-decouple-the-release-cycles-of-your-microservices/) on decoupling the release cycles of your services.
+If you want to ensure your provider is compatible with both the head version of your consumer, and the production version, you can use pact tagging to achieve this. To read more about this idea, check out this [blog post](https://www.rea-group.com/blog/enter-the-pact-matrix-or-how-to-decouple-the-release-cycles-of-your-microservices/) on decoupling the release cycles of your services.
 
 ### Step 1. Tag the production version of the pact
 


### PR DESCRIPTION
The link about the blog post "Enter the Pact Matrix. Or, how to decouple the release cycles of your microservices" is not working. 

I have changed it for what I think is a currently working link of the same blog post