### PR TITLE
chore: Add github.com/jbwheatley/pact4s to Scala implementation guide

### DIFF
--- a/website/docs/implementation_guides/scala.md
+++ b/website/docs/implementation_guides/scala.md
@@ -2,4 +2,5 @@
 title: Overview
 ---
 
-See the repository at [github.com/ITV/scala-pact](https://github.com/ITV/scala-pact)
+* [github.com/ITV/scala-pact](https://github.com/ITV/scala-pact) - independent implementation of the Pact specification. Only provides support for Version 2 of the specification, currently.
+* [github.com/jbwheatley/pact4s](https://github.com/jbwheatley/pact4s) - a lightweight wrapper on top of the Pact JVM implementation that makes Pact JVM easier to use in Scala projects. Supports the latest version of the specification.


### PR DESCRIPTION
Also note the differences in implementation and Pact specification support between the two Scala libraries.