### PR TITLE
feat: update pact-broker recommendation from tags to branch

### DIFF
--- a/website/docs/consumer/recommended_configuration.md
+++ b/website/docs/consumer/recommended_configuration.md
@@ -10,6 +10,7 @@ Using Pact + the Pact Broker in your release pipeline works most naturally if yo
 The recommended configuration for the consumer Pact publication configuration is:
 
 * `consumer version number`: the git sha (see [Versioning in the Pact Broker](/getting_started/versioning_in_the_pact_broker) for more info)
-* `consumer version tag`: the git branch
+* `consumer branch`: the git branch (Pact Broker version 2.82.0 onwards), to be used if both the consumer has support for publishing versions with branches and the provider has support for consumer version selectors with branches. See [Branches Support](/pact_broker/branches#support) for a list of supported libraries.
+* `consumer version tag`: the git branch, only recommended for Pact client libraries that don't yet have support for [branches](/pact_broker/branches#support). Tags that represent branches and environments, while still supported, have been superseded by first class support for branches and environments. Please read [this post](/blog/2021/10/08/why-we-are-getting-rid-of-tags) for more information.
 
 Making changes to pacts should happen on a branch of the consumer, and the branch should not be merged until there is a successful verification from the main branch of the provider.


### PR DESCRIPTION
Minor tweak to address a page that has not been updated to refer to `branch` as the new standard, in favor of tags.
https://docs.pact.io/consumer/recommended_configuration