### PR TITLE
feat: Documentation detailing new telemtry that is being introduced into Pact

### DIFF
--- a/website/docs/telemetry.md
+++ b/website/docs/telemetry.md
@@ -1,0 +1,58 @@
+---
+title: Telemetry
+---
+
+At Pact, we strive to develop great open source tools for the community. We rely on the community's input to help us iterate on and improve Pact. Telemetry is additional information that helps us to better understand the community's needs, diagnose issues, and prioritise feature work.
+
+Pact Broker and Pact libraries collect telemetry, such as generic usage metrics and system and environment information. For details of the types of telemetry collected, see Types of information collected.
+
+Pact does not collect personal information, such as usernames or email addresses. It also does not extract sensitive project-level information.
+
+When using Pact you can control whether telemetry is enabled, and the setting can be changed at any point in time. If telemetry remains enabled, telemetry data is sent in the background without requiring any additional customer interaction.
+
+This data is collected via [Google Analytics (GA)](https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide) and is accessible by Pact OSS maintainers.
+
+### Opt Out
+
+When using Pact locally a message will display in the terminal indicating that data will be collected. This message will contain instructions to disable telemetry if desired.
+
+```
+Please note: we are tracking events anonymously to gather important usage statistics like Pact-Ruby
+version and operating system. To disable tracking, set the 'PACT_DO_NOT_TRACK' environment variable
+to 'true'."
+```
+
+To opt out a 'PACT_DO_NOT_TRACK' environment variable needs to be set to 'true' in the environment you are using Pact in.
+
+```
+export PACT_DO_NOT_TRACK='true'
+echo $PACT_DO_NOT_TRACK
+true
+```
+
+### Types of Information Collected
+
+The information collected is a combination of data about the the environment and event occurring and parameters required by GA.
+
+| Data                        | Description                                                                                                  |
+| :-------------------------- | :----------------------------------------------------------------------------------------------------------- |
+| Version of API              | Version of the GA API used to collect telemetry                                                              |
+| Hash of hostname            | MD5 digest hash of the hostname. Used to anonymously detect repeat usage                                     |
+| Human readable library name | Human readable string to indicate which library generated the event e.g 'Pact JS'                            |
+| Library name                | The name of the library as it appears in github e.g 'pact-js'                                                |
+| Library version             | The semantic version of the Library that generated the event e.g v1.2.3                                      |
+| AIP                         | Anonymise IP flag set to '1' so that the IP address of the user will be anonymised when collecting telemetry |
+| Data Source                 | Environment where the code generating the event ran, e.g 'cli', 'client' or 'broker'                         |
+| OS and Arch                 | The OS and Arch of the machine that generated the event e.g 'linux-x86_64'                                   |
+| Plugin name                 | Where the event is generated from a plugin, the name of that plugin                                          |
+| Plugin version              | Where the event is generated from a plugin, the version of that plugin                                       |
+| Pact verification mode      | The language or test framework running the pact test that generated the event e.g 'Ruby', 'JUnit'            |
+| Platform version            | The version related to the above test framework or language                                                  |
+| Event                       | Human readable string to indicate which event occurred e.g 'Pacts verified'                                  |
+| Category                    | Used to determine if the test running was a provider test of consumer test                                   |
+| Action                      | Used to indicate an action that occurred in the code when the event was generated.                           |
+| Value                       | Numerical value that can be used to track any number related to the event, e.g number of pacts verified      |
+
+### Further Questions?
+
+For more information or help with Telemetry check out ['Where to go for help'](https://docs.pact.io/help/)

--- a/website/docs/telemetry.md
+++ b/website/docs/telemetry.md
@@ -2,9 +2,9 @@
 title: Telemetry
 ---
 
-At Pact, we strive to develop great open source tools for the community. We rely on the community's input to help us iterate on and improve Pact. Telemetry is additional information that helps us to better understand the community's needs, diagnose issues, and prioritise feature work.
+The Pact team strive to develop great open source tools for the community. We rely on the community's input to help us iterate on and improve Pact. Telemetry is additional information that helps us to better understand the community's needs, diagnose issues, and prioritise feature work.
 
-Pact Broker and Pact libraries collect telemetry, such as generic usage metrics and system and environment information. For details of the types of telemetry collected, see Types of information collected.
+Pact Broker and Pact libraries collect telemetry, such as generic usage metrics and system and environment information. For details of the types of telemetry collected, see [Types of information collected](#types-of-information-collected).
 
 Pact does not collect personal information, such as usernames or email addresses. It also does not extract sensitive project-level information.
 
@@ -14,44 +14,41 @@ This data is collected via [Google Analytics (GA)](https://developers.google.com
 
 ### Opt Out
 
-When using Pact locally a message will display in the terminal indicating that data will be collected. This message will contain instructions to disable telemetry if desired.
-
-```
-Please note: we are tracking events anonymously to gather important usage statistics like Pact-Ruby
-version and operating system. To disable tracking, set the 'PACT_DO_NOT_TRACK' environment variable
-to 'true'."
-```
-
-To opt out a 'PACT_DO_NOT_TRACK' environment variable needs to be set to 'true' in the environment you are using Pact in.
+In macOS and Linux operating systems, you can disable telemetry for a single session. To disable telemetry for your current session, run the following command to set the environment variable PACT_DO_NOT_TRACK to "true". You must repeat the command for each new terminal or session.
 
 ```
 export PACT_DO_NOT_TRACK='true'
-echo $PACT_DO_NOT_TRACK
-true
+```
+
+To disable telemetry in Windows:
+
+```
+setx PACT_DO_NOT_TRACK "true"
+refresh env
 ```
 
 ### Types of Information Collected
 
 The information collected is a combination of data about the the environment and event occurring and parameters required by GA.
 
-| Data                        | Description                                                                                                  |
-| :-------------------------- | :----------------------------------------------------------------------------------------------------------- |
-| Version of API              | Version of the GA API used to collect telemetry                                                              |
-| Hash of hostname            | MD5 digest hash of the hostname. Used to anonymously detect repeat usage                                     |
-| Human readable library name | Human readable string to indicate which library generated the event e.g 'Pact JS'                            |
-| Library name                | The name of the library as it appears in github e.g 'pact-js'                                                |
-| Library version             | The semantic version of the Library that generated the event e.g v1.2.3                                      |
-| AIP                         | Anonymise IP flag set to '1' so that the IP address of the user will be anonymised when collecting telemetry |
-| Data Source                 | Environment where the code generating the event ran, e.g 'cli', 'client' or 'broker'                         |
-| OS and Arch                 | The OS and Arch of the machine that generated the event e.g 'linux-x86_64'                                   |
-| Plugin name                 | Where the event is generated from a plugin, the name of that plugin                                          |
-| Plugin version              | Where the event is generated from a plugin, the version of that plugin                                       |
-| Pact verification mode      | The language or test framework running the pact test that generated the event e.g 'Ruby', 'JUnit'            |
-| Platform version            | The version related to the above test framework or language                                                  |
-| Event                       | Human readable string to indicate which event occurred e.g 'Pacts verified'                                  |
-| Category                    | Used to determine if the test running was a provider test of consumer test                                   |
-| Action                      | Used to indicate an action that occurred in the code when the event was generated.                           |
-| Value                       | Numerical value that can be used to track any number related to the event, e.g number of pacts verified      |
+| Data                        | Description                                                                                             |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------ |
+| Version of API              | Version of the GA API used to collect telemetry                                                         |
+| Hash of hostname            | MD5 digest hash of the hostname. Used to anonymously detect repeat usage                                |
+| Human readable library name | Human readable string to indicate which library generated the event e.g 'Pact JS'                       |
+| Library name                | The name of the library as it appears in github e.g 'pact-js'                                           |
+| Library version             | The semantic version of the Library that generated the event e.g v1.2.3                                 |
+| AIP                         | Anonymised IP address of the computer                                                                   |
+| Data Source                 | Environment where the code generating the event ran, e.g 'cli', 'client' or 'broker'                    |
+| OS and Arch                 | The OS and Arch of the machine that generated the event e.g 'linux-x86_64'                              |
+| Plugin name                 | Where the event is generated from a plugin, the name of that plugin                                     |
+| Plugin version              | Where the event is generated from a plugin, the version of that plugin                                  |
+| Pact verification mode      | The language or test framework running the pact test that generated the event e.g 'Ruby', 'JUnit'       |
+| Platform version            | The version related to the above test framework or language                                             |
+| Event                       | Human readable string to indicate which event occurred e.g 'Pacts verified'                             |
+| Category                    | Used to determine if the test running was a provider test of consumer test                              |
+| Action                      | Used to indicate an action that occurred in the code when the event was generated.                      |
+| Value                       | Numerical value that can be used to track any number related to the event, e.g number of pacts verified |
 
 ### Further Questions?
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -182,10 +182,6 @@ const siteConfig = {
             },{
               label: 'Help',
               to: 'help'
-            },
-            {
-              label: 'Telemetry',
-              to: 'telemetry',
             }
           ],
         },

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -182,6 +182,10 @@ const siteConfig = {
             },{
               label: 'Help',
               to: 'help'
+            },
+            {
+              label: 'Telemetry',
+              to: 'telemetry',
             }
           ],
         },

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -145,7 +145,8 @@
       ]
     },
     "implementation_guides/workshops",
-    "faq"
+    "faq",
+    "telemetry"
   ],
   "guides": {
     "Consumer": [

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,114 +1,161 @@
 {
-  "docs": {
-    "Pact command line tools": ["implementation_guides/cli"],
-    "Pact JS": [
-      "implementation_guides/javascript",
-      "implementation_guides/javascript/readme",
-      "implementation_guides/javascript/roadmap",
-      "implementation_guides/javascript/changelog",
-      "implementation_guides/javascript/contributing"
-    ],
-    "Pact JVM": [
-      "implementation_guides/jvm",
-      "implementation_guides/jvm/readme",
-      "implementation_guides/jvm/matching",
-      {
-        "type": "category",
-        "label": "Consumer",
-        "items": [
-          "implementation_guides/jvm/consumer/java8",
-          "implementation_guides/jvm/consumer/junit",
-          "implementation_guides/jvm/consumer/junit5",
-          "implementation_guides/jvm/consumer",
-          "implementation_guides/jvm/consumer/specs2",
-          "implementation_guides/jvm/consumer/groovy"
-        ]
-      },
-      {
-        "type": "category",
-        "label": "Provider",
-        "items": [
-          "implementation_guides/jvm/provider/junit5spring",
-          "implementation_guides/jvm/provider/junit",
-          "implementation_guides/jvm/provider/maven",
-          "implementation_guides/jvm/provider/gradle",
-          "implementation_guides/jvm/provider/junit5",
-          "implementation_guides/jvm/provider",
-          "implementation_guides/jvm/provider/sbt",
-          "implementation_guides/jvm/provider/lein",
-          "implementation_guides/jvm/provider/spring",
-          "implementation_guides/jvm/provider/scalatest",
-          "implementation_guides/jvm/provider/specs2"
-        ]
-      },
-      "implementation_guides/jvm/pact-jvm-server",
-      "implementation_guides/jvm/changelog"
-    ],
-    "Pact Net": [
-      "implementation_guides/net",
-      "implementation_guides/net/readme"
-    ],
-    "Pact Go": [
-      "implementation_guides/go",
-      "implementation_guides/go/readme",
-      "implementation_guides/go/troubleshooting",
-      "implementation_guides/go/changelog"
-    ],
-    "Pact Python": [
-      "implementation_guides/python",
-      "implementation_guides/python/readme",
-      "implementation_guides/python/changelog"
-    ],
-    "Pact Swift": ["implementation_guides/swift"],
-    "Pact Scala": ["implementation_guides/scala"],
-    "Pact PHP": ["implementation_guides/php"],
-    "Pact Ruby": [
-      "implementation_guides/ruby/README",
-      "implementation_guides/ruby/creating_pacts",
-      "implementation_guides/ruby/matching",
-      "implementation_guides/ruby/publishing_pacts",
-      "implementation_guides/ruby/verifying_pacts",
-      "implementation_guides/ruby/provider_states",
-      "implementation_guides/ruby/configuration",
-      "implementation_guides/ruby/gotchas"
-    ],
-    "Pact Rust": [
-      "implementation_guides/rust",
-      "implementation_guides/rust/pact_consumer",
-      "implementation_guides/rust/pact_matching",
-      "implementation_guides/rust/pact_mock_server",
-      "implementation_guides/rust/pact_mock_server_cli",
-      "implementation_guides/rust/pact_mock_server_ffi",
-      "implementation_guides/rust/pact_verifier",
-      "implementation_guides/rust/pact_verifier_cli",
-      {
-        "type": "category",
-        "label": "Changelogs",
-        "items": [
-          "implementation_guides/rust/pact_consumer/changelog",
-          "implementation_guides/rust/pact_matching/changelog",
-          "implementation_guides/rust/pact_mock_server/changelog",
-          "implementation_guides/rust/pact_mock_server_cli/changelog",
-          "implementation_guides/rust/pact_mock_server_ffi/changelog",
-          "implementation_guides/rust/pact_verifier/changelog",
-          "implementation_guides/rust/pact_verifier_cli/changelog"
-        ]
-      }
-    ],
-    "Pact C++": [
-      "implementation_guides/cpp",
-      "implementation_guides/cpp/consumer",
-      "implementation_guides/cpp/consumer/changelog"
-    ],
-    "Pact on Docker": ["docker"],
-    "Other languages": ["implementation_guides/other_languages"],
-    "Feature support": [
-      "roadmap/feature_support",
-      "roadmap/roadmap",
-      "wrapper_implementations"
-    ],
-    "Stubs": ["getting_started/stubs"]
-  },
+  "docs": [
+    {
+      "Pact command line tools": [
+        "implementation_guides/cli"
+      ]
+    },
+    {
+      "Pact JS": [
+        "implementation_guides/javascript",
+        "implementation_guides/javascript/readme",
+        "implementation_guides/javascript/roadmap",
+        "implementation_guides/javascript/changelog",
+        "implementation_guides/javascript/contributing"
+      ]
+    },
+    {
+      "Pact JVM": [
+        "implementation_guides/jvm",
+        "implementation_guides/jvm/readme",
+        "implementation_guides/jvm/matching",
+        {
+          "type": "category",
+          "label": "Consumer",
+          "items": [
+            "implementation_guides/jvm/consumer/java8",
+            "implementation_guides/jvm/consumer/junit",
+            "implementation_guides/jvm/consumer/junit5",
+            "implementation_guides/jvm/consumer",
+            "implementation_guides/jvm/consumer/specs2",
+            "implementation_guides/jvm/consumer/groovy"
+          ]
+        },
+        {
+          "type": "category",
+          "label": "Provider",
+          "items": [
+            "implementation_guides/jvm/provider/junit5spring",
+            "implementation_guides/jvm/provider/junit",
+            "implementation_guides/jvm/provider/maven",
+            "implementation_guides/jvm/provider/gradle",
+            "implementation_guides/jvm/provider/junit5",
+            "implementation_guides/jvm/provider",
+            "implementation_guides/jvm/provider/sbt",
+            "implementation_guides/jvm/provider/lein",
+            "implementation_guides/jvm/provider/spring",
+            "implementation_guides/jvm/provider/scalatest",
+            "implementation_guides/jvm/provider/specs2"
+          ]
+        },
+        "implementation_guides/jvm/pact-jvm-server",
+        "implementation_guides/jvm/changelog"
+      ]
+    },
+    {
+      "Pact Net": [
+        "implementation_guides/net",
+        "implementation_guides/net/readme"
+      ]
+    },
+    {
+      "Pact Go": [
+        "implementation_guides/go",
+        "implementation_guides/go/readme",
+        "implementation_guides/go/troubleshooting",
+        "implementation_guides/go/changelog"
+      ]
+    },
+    {
+      "Pact Python": [
+        "implementation_guides/python",
+        "implementation_guides/python/readme",
+        "implementation_guides/python/changelog"
+      ]
+    },
+    {
+      "Pact Swift": [
+        "implementation_guides/swift"
+      ]
+    },
+    {
+      "Pact Scala": [
+        "implementation_guides/scala"
+      ]
+    },
+    {
+      "Pact PHP": [
+        "implementation_guides/php"
+      ]
+    },
+    {
+      "Pact Ruby": [
+        "implementation_guides/ruby/README",
+        "implementation_guides/ruby/creating_pacts",
+        "implementation_guides/ruby/matching",
+        "implementation_guides/ruby/publishing_pacts",
+        "implementation_guides/ruby/verifying_pacts",
+        "implementation_guides/ruby/provider_states",
+        "implementation_guides/ruby/configuration",
+        "implementation_guides/ruby/gotchas"
+      ]
+    },
+    {
+      "Pact Rust": [
+        "implementation_guides/rust",
+        "implementation_guides/rust/pact_consumer",
+        "implementation_guides/rust/pact_matching",
+        "implementation_guides/rust/pact_mock_server",
+        "implementation_guides/rust/pact_mock_server_cli",
+        "implementation_guides/rust/pact_mock_server_ffi",
+        "implementation_guides/rust/pact_verifier",
+        "implementation_guides/rust/pact_verifier_cli",
+        {
+          "type": "category",
+          "label": "Changelogs",
+          "items": [
+            "implementation_guides/rust/pact_consumer/changelog",
+            "implementation_guides/rust/pact_matching/changelog",
+            "implementation_guides/rust/pact_mock_server/changelog",
+            "implementation_guides/rust/pact_mock_server_cli/changelog",
+            "implementation_guides/rust/pact_mock_server_ffi/changelog",
+            "implementation_guides/rust/pact_verifier/changelog",
+            "implementation_guides/rust/pact_verifier_cli/changelog"
+          ]
+        }
+      ]
+    },
+    {
+      "Pact C++": [
+        "implementation_guides/cpp",
+        "implementation_guides/cpp/consumer",
+        "implementation_guides/cpp/consumer/changelog"
+      ]
+    },
+    {
+      "Pact on Docker": [
+        "docker"
+      ]
+    },
+    {
+      "Other languages": [
+        "implementation_guides/other_languages"
+      ]
+    },
+    {
+      "Feature support": [
+        "roadmap/feature_support",
+        "roadmap/roadmap",
+        "wrapper_implementations"
+      ]
+    },
+    {
+      "Stubs": [
+        "getting_started/stubs"
+      ]
+    },
+    "telemetry"
+  ],
   "getting-started": [
     {
       "type": "category",
@@ -145,8 +192,7 @@
       ]
     },
     "implementation_guides/workshops",
-    "faq",
-    "telemetry"
+    "faq"
   ],
   "guides": {
     "Consumer": [
@@ -256,7 +302,9 @@
       {
         "type": "category",
         "label": "API Docs",
-        "items": ["pact_broker/api/webhooks"]
+        "items": [
+          "pact_broker/api/webhooks"
+        ]
       },
       "pact_broker/changelog"
     ]
@@ -275,8 +323,15 @@
       ]
     }
   ],
-  "help": ["help", "help/how_to_ask_for_help", "help/amas"],
+  "help": [
+    "help",
+    "help/how_to_ask_for_help",
+    "help/amas"
+  ],
   "docs-other": {
-    "First Category": ["doc4", "doc5"]
+    "First Category": [
+      "doc4",
+      "doc5"
+    ]
   }
 }


### PR DESCRIPTION
The purpose of this PR is to outline the purpose, intention and specifics of the telemetry that will be rolled out as part of ongoing development of Pact. This document is the outcome of discussions with Pact maintainers and describes the type of data that will be collected, as well as how to opt-out of sending telemetry.