### PR TITLE
docs - update recipes relative links

### DIFF
--- a/website/docs/recipes.md
+++ b/website/docs/recipes.md
@@ -8,13 +8,13 @@ Recipes and pre-built integrations to test common scenarios in Pact
 
 | Recipe/Integration                                     | Description                                                                                                                         |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| [GraphQL](recipes/graphql)                             | Strategies for testing GraphQL endpoints (example with Apollo)                                                                      |
-| [API Gateway](recipes/apigateway)                      | Strategies for dealing with API Gateways, such as AWS API Gateway, Kong etc.                                                        |
+| [GraphQL](graphql)                             | Strategies for testing GraphQL endpoints (example with Apollo)                                                                      |
+| [API Gateway](apigateway)                      | Strategies for dealing with API Gateways, such as AWS API Gateway, Kong etc.                                                        |
 | [Lambda/FaaS (Asynchronous)](recipes/lambdaasync)      | How to write contract tests for asynchronous lambda functions / FaaS                                                                |
-| [Lambda (HTTP)](recipes/lambdahttp)                    | How to write contract tests for HTTP based lambdas with AWS SAM                                                                     |
-| [Cypress](recipes/cypress)                             | Best practices for integrating Pact with Cypress, and converting your cypress `cy.route()` / `cy.intercept()` calls into pact files |
+| [Lambda (HTTP)](lambdahttp)                    | How to write contract tests for HTTP based lambdas with AWS SAM                                                                     |
+| [Cypress](cypress)                             | Best practices for integrating Pact with Cypress, and converting your cypress `cy.route()` / `cy.intercept()` calls into pact files |
 | [MSW](https://github.com/you54f/msw-pact)              | Library for integrating MSW with Pact                                                                                               |
 | [NestJS](https://github.com/omermorad/nestjs-pact)     | Library for integrating Pact with NestJS                                                                                            |
-| [Kafka](recipes/kafka)                                 | How to test Kafka messages with Pact                                                                                                |
+| [Kafka](kafka)                                 | How to test Kafka messages with Pact                                                                                                |
 | [Jest](https://github.com/pact-foundation/jest-pact)   | A Pact adaptor for to allow you to easily run tests with Jest                                                                       |
 | [Mocha](https://github.com/pact-foundation/mocha-pact) | A Pact adaptor for to allow you to easily run tests with Mocha                                                                      |


### PR DESCRIPTION
Links resolving to https://docs.pact.io/recipes/recipes/graphql when viewed from recipes pages

see slack thread for mention of issue

https://pact-foundation.slack.com/archives/CAN147DFD/p1645115313768419?thread_ts=1641990628.004600&channel=CAN147DFD&message_ts=1645115313.768419