### PR TITLE
fix: Strict usage of "test" for consumer and "verification" for provider

### DIFF
--- a/website/docs/consumer/contract_tests_not_functional_tests.md
+++ b/website/docs/consumer/contract_tests_not_functional_tests.md
@@ -88,8 +88,8 @@ In short, your Pact scenarios should not dig into the business logic of the Prov
 | :--- | :--- |
 | Does the consumer code make the expected request? | Pact consumer tests \(Pact mock service\) |
 | Does the consumer correctly handle the expected response? | Pact consumer tests \(using your own assertions\) |
-| Does the provider handle the expected request? | Pact provider tests \(verifier\) |
-| Does the provider return the expected response? | Pact provider tests \(verifier\) |
+| Does the provider handle the expected request? | Pact provider verifications \(Pact verifier CLI\) |
+| Does the provider return the expected response? | Pact provider verifications \(Pact verifier CLI\) |
 | Does the provider do the right thing with the request? | Provider's own functional tests |
 
 ### Does the consumer code make the expected request?


### PR DESCRIPTION
I would suggest staying strict with the terminology:

- Use the noun "test" and the verb "test" to specify the actions done by, and only by, the _consumers_;

- Use the noun "verification" and the verb "verify" to specify the actions done by, and only by, the _providers_.

So, in the context of contract testing with Pact, a _provider_ would never test; a _provider_ would (only) verify.

If I could be even more pedantic, I would say that while a _provider_ does verify a Pact, a _consumer_ does *not** test a Pact, but test **with** a Pact.