### PR TITLE
chore: disable trailing slash

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -190,6 +190,8 @@ const siteConfig = {
   /* path to images for header/footer */
   favicon: "img/favicon.ico",
 
+  trailingSlash: false,
+
   // This copyright info is used in /core/Footer.js and blog RSS/Atom feeds.
 
   // highlight: {


### PR DESCRIPTION
Setting `trailingSlash: false` generates `folder/file.html`, rather than `folder/file/index.html`. This means that when netlify gets a request for `folder/file` it returns `folder/file.html`, and when it receives a request for `folder/file/` (trailing slash) it redirects to `folder/file`. Previously it was the other way around.

Because `folder/file` returns an actual file now, and not a redirect, the URl matches the canonical URl in the sitemap.xml file, and so this should fix the Angolia Crawler issue.