### PR TITLE
fix: addDocusaurusMeta

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -85,6 +85,8 @@ const siteConfig = {
       apiKey: "9d560a8ae18f8a304605caf0130e9874",
       indexName: "pact",
     },
+    
+    metadata: [ {name: 'docsearch:docusaurus_tag', content: 'docs-default-current'} ],
 
     navbar: {
       title: "Pact",


### PR DESCRIPTION
Add metadata as per https://docusaurus.io/docs/api/themes/configuration#metadata to enable doc search again
___

**Issue**

Doc search on docs.pact.io is now working

**Cause**

Looking the at the search request that is made from the [docs pages]( https://docs.pact.io/)., it doesn't return any results.

It appears to be down to the `requests.params.facetFilters` namely the `docusaurus_tag`'s

They are set to `["language:en",["docusaurus_tag:default","docusaurus_tag:docs-default-current"]]`

if I rerun the request dropping the array of `docusauraus_tag`'s appears to fix the request.

I tried isolating either of the `docusauraus_tag`'s and removing them from the array of `facetFilters` to no avail.

**Remediation**

https://v1.docusaurus.io/docs/en/search.html#extra-search-options
https://www.algolia.com/doc/api-reference/api-parameters/filters/#facet-filters

I think this issues are relevant :- TL;DR. looks out our config isn't quite right and we don't have pages marked with those tags.

https://github.com/facebook/docusaurus/issues/5084#issuecomment-870785155
https://github.com/facebook/docusaurus/issues/3805

Looks like we made need to add some meta tags to the docs site - as they are not currently embedded in the site

`<meta name="docsearch:docusaurus_tag" content="docs-default-current">`


Hope this might work - we can add via the docusaurus config, metadata - see [here](https://docusaurus.io/docs/api/themes/configuration#metadata)