### PR TITLE
chore: update provider badges with real examples

### DIFF
--- a/website/docs/pact_broker/advanced_topics/provider_verification_badges.md
+++ b/website/docs/pact_broker/advanced_topics/provider_verification_badges.md
@@ -6,8 +6,7 @@ _See the the_ [_Badges_](/pact_broker/configuration/features#badges) _section of
 
 If you are publishing [Provider verification results](provider_verification_results.md) to your Pact Broker \(v2.3.0+\), you can also display the verification status in your READMEs using a shiny badge like this one:
 
-[![Pact Status](https://cdn.rawgit.com/wiki/pact-foundation/pact_broker/images/foo-bar-badge-verified.svg)](https://test.pactflow.io)
-
+[![Pact Status](https://test.pactflow.io/pacticipants/FrontendWebsite/branches/test/latest-version/can-i-deploy/to-environment/test/badge)](https://test.pactflow.io/pacticipants/FrontendWebsite/branches/test/latest-version/can-i-deploy/to-environment/test)
 
 ## Can I Deploy badge
 
@@ -18,6 +17,8 @@ If you are publishing [Provider verification results](provider_verification_resu
 Requires version 2.94+ of the Pact Broker
 
 Returns a status badge that can be displayed in a README file that indicates whether the latest version of a pacticipant from a particular branch can be deployed to the specified environment.
+
+[![Can I Deploy BRANCH to ENVIRONMENT](https://test.pactflow.io/pacticipants/FrontendWebsite/branches/test/latest-version/can-i-deploy/to-environment/test/badge)](https://test.pactflow.io/pacticipants/FrontendWebsite/branches/test/latest-version/can-i-deploy/to-environment/test)
 
 ```text
 [![Can I Deploy BRANCH to ENVIRONMENT](https://your-broker/pacticipants/PACTICIPANT/branches/BRANCH/latest-version/can-i-deploy/to-environment/ENVIRONMENT/badge)](https://your-broker/hal-browser/browser.html#https://your-broker/pacticipants/PACTICIPANT/branches/BRANCH/latest-version/can-i-deploy/to-environment/ENVIRONMENT)
@@ -31,9 +32,13 @@ Requires version 2.62+ of the Pact Broker.
 
 Returns a status badge that can be displayed in a README file that indicates whether the latest version of a pacticipant with a specified tag can be deployed to the specified environment as identified by a tag.
 
+[![Can I deploy Foo status](https://test.pactflow.io/pacticipants/FrontendWebsite/latest-version/test/can-i-deploy/to/test/badge)](https://test.pactflow.io/pacticipants/FrontendWebsite/latest-version/test/can-i-deploy/to/test)
+
 ```text
 [![Can I deploy Foo status](https://your-broker/pacticipants/PACTICIPANT/latest-version/TAG/can-i-deploy/to/ENVIRIONMENT_TAG/badge)](https://your-broker/pacticipants/PACTICIPANT/latest-version/TAG/can-i-deploy/to/ENVIRIONMENT_TAG)
 ```
+
+[![Can I deploy Foo status](https://test.pactflow.io/pacticipants/FrontendWebsite/latest-version/test/can-i-deploy/to/test/badge?label=my+custom+label+here)](https://test.pactflow.io/pacticipants/FrontendWebsite/latest-version/test/can-i-deploy/to/test)
 
 To set a custom label for the badge, set the `label` query parameter. eg `?label=my+custom+label+here`.
 
@@ -55,6 +60,8 @@ The URL of the badge is the URL of the latest pact with `/badge.svg` appended, a
 
 The markdown to include in your README is as follows:
 
+[![Foo/Bar Pact Status](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest/badge.svg)](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest)
+
 ```text
 [![Foo/Bar Pact Status](https://your-broker/pacts/provider/PROVIDER/consumer/CONSUMER/latest/badge.svg)](https://your-broker)
 ```
@@ -62,7 +69,7 @@ The markdown to include in your README is as follows:
 For example:
 
 ```text
-[![Foo/Bar Pact Status](https://test.pactflow.io/pacts/provider/Bar/consumer/Foo/latest/badge.svg)](https://test.pactflow.io)
+[![Foo/Bar Pact Status](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest/badge.svg)](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest)
 ```
 
 #### With consumer and provider tags
@@ -75,17 +82,19 @@ If you are using tags for both the consumer and provider versions \(this is reco
 
 ### Options
 
-[![Pact Status](https://cdn.rawgit.com/wiki/pact-foundation/pact_broker/images/long-badge.svg)](https://test.pactflow.io)
+[![Pact Status](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest/badge.svg)](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest)
 
 If your consumer and provider name make your badge too long to be aesthetically pleasing, you can shorten it in the following ways.
 
 * Show just the consumer or provider name by adding `?label=consumer` or `?label=provider` to the end of the URL.
 
-  [![Pact Status](https://cdn.rawgit.com/wiki/pact-foundation/pact_broker/images/consumer-badge.svg)](https://test.pactflow.io)
+  [![Pact Status](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest/badge.svg?label=consumer)](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest)
 
 * Use the pacticipant's initials by adding `?initials=true`
 
-  [![Pact Status](https://cdn.rawgit.com/wiki/pact-foundation/pact_broker/images/initials-badge.svg)](https://test.pactflow.io)
+  [![Pact Status](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest/badge.svg?initials=true)](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest)
 
 * Use both the `label` and the `initials` params to show only the initials of the consumer or provider.
+
+  [![Pact Status](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest/badge.svg?initials=true&label=consumer)](https://test.pactflow.io/pacts/provider/ProductService/consumer/FrontendWebsite/latest)
 


### PR DESCRIPTION
fixes #117

note this uses a test.pactflow.io instance. this pairing 

[here](https://test.pactflow.io/matrix?q[][pacticipant]=FrontendWebsite&q[][version]=1.0.0&q[])[pacticipant]=ProductService&latestby=cvpv