### PR TITLE
chore: small typos in recommended setup

### DIFF
--- a/website/docs/provider/recommended_configuration.md
+++ b/website/docs/provider/recommended_configuration.md
@@ -108,12 +108,12 @@ The following examples require support for the "pacts for verification" API in y
 
         consumer_version_selectors [
             { tag: 'main', latest: true },
-            { tag: ENV['GIT_BRANCH'], latest: true },
-            { tag: 'test', latest: true }
+            { tag: provider_branch, latest: true },
+            { tag: 'test', latest: true },
             { tag: 'production', latest: true }
         ]
         enable_pending true
-        include_wip_pacts_since ENV['GIT_BRANCH'] == "main" ? "2020-01-01" : nil
+        include_wip_pacts_since provider_branch == "main" ? "2020-01-01" : nil
       end
     end
   ```


### PR DESCRIPTION
## Context 

While working through some of the setup docs, I noticed some small typos on the Ruby `Recommended configuration for verifying pacts` page. One missing comma, and some references that could be leveraging an already declared variable. 

If you copy paste the recommended code without having passing in a `GIT_BRANCH` env variable, a `rake pact:verify` command would fail with this error:

```bash
{"errors":{"consumerVersionSelectors":["tag can't be blank at index 0"]}} (Pact::Hal::ErrorResponseReturned)
```

## Validation

Ran `rake pact:verify` with these small changes included in a local project.

Preview new page at -> https://deploy-preview-135--docs-pact-io.netlify.app/provider/recommended_configuration