### PR TITLE
Actualize link to comparison with similar technologies

### DIFF
--- a/website/docs/faq/convinceme.md
+++ b/website/docs/faq/convinceme.md
@@ -82,7 +82,7 @@ Pact is like VCR in reverse. VCR records actual provider behaviour, and verifies
 * The ability to immediately see which consumers will be broken if a change is made to the provider API.
 * When using the [Pact Broker](https://github.com/pact-foundation/pact_broker), the ability to map the relationships between your services.
 
-See [https://github.com/pact-foundation/pact-ruby/wiki/FAQ\#how-does-pact-differ-from-vcr](https://github.com/pact-foundation/pact-ruby/wiki/FAQ#how-does-pact-differ-from-vcr) for more examples of similar technologies.
+See [https://docs.pact.io/getting_started/comparisons](https://docs.pact.io/getting_started/comparisons) for more examples of similar technologies.
 
 ### ...but I use Swagger/OpenAPI?
 


### PR DESCRIPTION
The previous link (https://github.com/pact-foundation/pact-ruby/wiki/FAQ\#how-does-pact-differ-from-vcr) doesn't seem to be valid for provided description (See "..."  for more examples of similar technologies.).