### PR TITLE
More branch updates

### DIFF
--- a/website/docs/pact_broker/advanced_topics/consumer_version_selectors.md
+++ b/website/docs/pact_broker/advanced_topics/consumer_version_selectors.md
@@ -65,6 +65,29 @@ This is not an exhaustive list, but shows most of the usecases.
 
 The Pact Broker API for retrieving pacts by selectors deduplicates the pacts based on their *content*. This means that if the same content was published in multiple selected pacts, the verification for that content will only need to run once. This is quite common when there hasn't been a change to a pact for a while, and the same pact content is present in development, test and production pacts.
 
+## Docs
+
+You can checkout code-snippets below, but here are some links to either documentation, or source code, from the respective languages, around their use of consumer version selectors. Ideally all languages should support raw json version selectors, to allow for extensiblity in the future.
+
+- JavaScript
+  - <https://docs.pact.io/implementation_guides/javascript/docs/provider#verification-options>
+  - <https://github.com/pact-foundation/pact-js-core/blob/master/src/verifier/types.ts#L3>
+- Java
+  - <https://docs.pact.io/implementation_guides/jvm/provider/junit#selecting-the-pacts-to-verify-with-consumer-version-selectors-4314>
+- Gradle
+  - <https://docs.pact.io/implementation_guides/jvm/provider/gradle#using-consumer-version-selectors-4310>
+- Ruby
+  - <https://docs.pact.io/implementation_guides/ruby/verifying_pacts#fetching-pacts-from-a-pact-broker>
+  - <https://github.com/pact-foundation/pact-ruby/blob/master/lib/pact/pact_broker/pact_selection_description.rb>
+- Python - Takes raw json consumer_version_selectors
+  - <https://github.com/pact-foundation/pact-python/blob/89733d6470cfa4b57102438c464f053093ddd858/pact/verifier.py#L109>
+- C#
+  - <https://github.com/pact-foundation/pact-net/blob/master/docs/upgrading-to-4.md#provider-tests>
+  - <https://github.com/pact-foundation/pact-net/blob/master/src/PactNet.Abstractions/Verifier/ConsumerVersionSelector.cs>
+- Golang
+  - <https://github.com/pact-foundation/pact-go/blob/2.x.x/docs/provider.md#selecting-pacts-to-verify>
+  - <https://github.com/pact-foundation/pact-go/blob/master/types/consumer_version_selector.go>
+
 ## Code examples with branches
 
 ### Verifying the latest development, test and master pacts

--- a/website/docs/pact_broker/advanced_topics/pending_pacts.md
+++ b/website/docs/pact_broker/advanced_topics/pending_pacts.md
@@ -103,7 +103,7 @@ The pending property *is not used* by the pact verification build that is trigge
 
 [Work in progress pacts](/pact_broker/advanced_topics/wip_pacts) always have the pending flag set to true.
 
-## Examples with branches
+## Examples
 
 Let's walk through the "pending" lifecycle of a particular pact content version with an interaction that is implemented directly on the `main` branch of a provider.
 

--- a/website/docs/pact_broker/advanced_topics/pending_pacts.md
+++ b/website/docs/pact_broker/advanced_topics/pending_pacts.md
@@ -13,27 +13,47 @@ The logic for the "pending pacts" feature is quite technical and you don't need 
 You can enable the pending pacts feature by setting `enablePending` (or equivalent for your language) to `true` in the [provider verification configuration](/provider/recommended_configuration#verification-triggered-by-provider-change). In the future, this feature will be enabled by default.
 :::
 
+:::tip tl;dr - As a provider, protect your builds by enabling pending pacts
+
+- Ensure consumer has configured the mainBranch property
+- Ensure consumer sets branch and version properties when publishing pacts
+- Ensure provider sets branch and version properties when verifying pacts
+- enable the pending pacts feature by setting `enablePending` (or equivalent for your language) to `true` in the [provider verification configuration](/provider/recommended_configuration#verification-triggered-by-provider-change)
+:::
+
 ## Why is this feature required?
 
 Without the pending pacts feature turned on, changes made to pacts by the consumer team can block the provider team from being able to deploy, even when the provider is compatible with the deployed version of the consumer.
 
-To demonstrate how it works, let's compare an example workflow with and without the "pending" feature enabled. Note that the pending feature is only applicable to the main provider release pipeline, not the provider build that gets triggered by the `contract_content_changed` webhook.
+To demonstrate how it works, let's compare an example workflow with and without the "pending" feature enabled. Note that the pending feature is only applicable to the main provider release pipeline, not the provider build that gets triggered by the `contract_requiring_verification_published` webhook.
 
 ### Without the pending pacts feature enabled
 
-1. Provider is configured to verify the pacts with tags `main` and `production`. Both pacts are currently passing verification from the `main` branch of the provider.
-2. Consumer publishes a pact with tag `main` that has a new, unsupported interaction in it (ideally, this should have been done in a feature branch, but for the sake of this example, we'll assume best practice advice was not followed).
-3. Next time the provider build runs, the verification of the `main` pact fails, and the verification task exits with an error. The broken build stops the provider from deploying, even though the verification for the `production` pact passed.
-4. The provider team is very annoyed!
+1. Provider is configured to verify the pacts with following consumer version selectors.
+   1. `{ mainBranch: true }` and `{ deployedOrReleased: true }`,
+   2. `enablePending` option is set to `false`.
+2. Provider build runs, both retrieved pacts (the consumers `main` branch pact, and the consumer pact deployed to `production`) are currently passing verification from the `main` branch of the provider.
+3. Consumer publishes a pact against the branch `main` that has a new, unsupported interaction in it (ideally, this should have been done in a feature branch, but for the sake of this example, we'll assume best practice advice was not followed).
+4. Next time the provider build runs,
+   1. the verification of the consumers configured `main` branch pact fails,
+   2. **AND** *because `enablePending` is turned off, **the verification task exits with an error***.
+   3. The broken build stops the provider from deploying, even though the verification for the `deployedOrReleased` consumer pact in `production` passed.
+5. The provider team is very annoyed!
 
 ### With the pending pacts feature enabled
 
-1. Provider is configured to verify the pacts with tags `main` and `production`, AND the `enablePending` option is set to true.
-2. Consumer publishes a new pact with tag `main` that has a new unsupported interaction in it (as above).
-3. Next time the provider build runs, the verification of the `main` pact fails **BUT** _because `enablePending` is turned on, the verification task does not exit with an error_. This means the pipeline continues and the provider can still deploy to production, because the verification for the `production` pact passed.
-4. Provider team is happy!
+1. Provider is configured to verify the pacts with following consumer version selectors.
+   1. `{ mainBranch: true }` and `{ deployedOrReleased: true }`,
+   2. `enablePending` option is set to `true`.
+2. Provider build runs, both retrieved pacts (the consumers `main` branch pact, and the consumer pact deployed to `production`) are currently passing verification from the `main` branch of the provider.
+3. Consumer publishes a new pact against the branch `main` that has a new unsupported interaction in it (ideally, this should have been done in a feature branch, but for the sake of this example, we'll assume best practice advice was not followed).
+4. Next time the provider build runs,
+   1. the verification of the consumers configured `main` branch pact fails
+   2. **BUT** *because `enablePending` is turned on, **the verification task does not exit with an error***.
+   3. This means the pipeline continues and the provider can still deploy to production, because the verification for the `deployedOrReleased` consumer pact in `production` passed.
+5. Provider team is happy!
 
-Note that in both of these examples, the verification result sent back to the Pact Broker for the `main` pact is still a failure, and the consumer cannot be deployed in either example, as the features it requires are not yet supported (this is why a feature branch should have been used, as the consumer's own pipeline will be blocked by `can-i-deploy` reporting that the provider does not yet support the new interaction).
+Note that in both of these examples, the verification result sent back to the Pact Broker for the consumers `main` pact is still a failure, and the consumer cannot be deployed in either example, as the features it requires are not yet supported (this is why a feature branch should have been used, as the consumer's own pipeline will be blocked by `can-i-deploy` reporting that the provider does not yet support the new interaction).
 
 [Watch a video that explains this concept](https://youtu.be/VnOy9Sv9Opo).
 
@@ -49,19 +69,19 @@ The feature is enabled by setting `enablePending` (or `enabled_pending` or `Enab
 
 ### How it is calculated
 
-The "pending" status of a pact is a _dynamically calculated_ property, determined by the Pact Broker when the pacts are fetched for verification. It is based on:
+The "pending" status of a pact is a *dynamically calculated* property, determined by the Pact Broker when the pacts are fetched for verification. It is based on:
 
 - The content of the contract (also known as the "pact version").
   - Note that the Pact Broker deduplicates and versions the contents of the published pacts. Publishing the same content for multiple consumer versions results in each of the consumer versions being associated with the same underlying pact content version.
 - The verification results and their associated branches that have been published to the Pact Broker for the pact content.
-  - Note that the verification results belong to the pact _content_ itself, irrespective of which consumer version published it.
-- The currrent branch of the provider, as specified by the provider tags in the verification configuration
+  - Note that the verification results belong to the pact *content* itself, irrespective of which consumer version published it.
+- The currrent branch of the provider, as specified by the provider branch property in the verification configuration
 
 **A pact's content is pending for all branches of a provider until the first successful verification has been published. From then on, it is no longer pending for the provider branch that published the successful verification, and will not be pending for any other new provider branches created thereafter. It will stay in pending for branches that already existed at the time of the successful verification.**
 
-The provider branch (inferred from its tags) is used to determine the pending status because it is common to implement new features of a provider on a feature branch. If the provider branch was not taken in to consideration, a newly published successful verification on `feat-x` branch of the provider would suddenly cause the verification of that content by the `main` branch of the provider to fail.
+The provider branch is used to determine the pending status because it is common to implement new features of a provider on a feature branch. If the provider branch was not taken in to consideration, a newly published successful verification on `feat-x` branch of the provider would suddenly cause the verification of that content by the `main` branch of the provider to fail.
 
-This diagram, while not entirely accurate (there is no stored state, it's a dynamic calculation) is a helpful way of understanding the pending state transitions for a pact version and a particular provider branch/tag.
+This diagram, while not entirely accurate (there is no stored state, it's a dynamic calculation) is a helpful way of understanding the pending state transitions for a pact version and a particular provider branch.
 
 ![Pending pact state diagram](/img/pending-state-diagram.png)
 
@@ -69,36 +89,61 @@ This diagram, while not entirely accurate (there is no stored state, it's a dyna
 
 The value of the "pending" property is used by the pact verification task to determine whether or not to exit with an error status for a failed pact.
 
-When a pact version is considered "pending", then any mismatches during verification _will not_ cause the overall verification task to fail. When a pact is _not_ considered "pending" then mismatches _will_ cause the overall verification task to fail (until the introduction of this feature, this was the default behaviour).
+When a pact version is considered "pending", then any mismatches during verification *will not* cause the overall verification task to fail. When a pact is *not* considered "pending" then mismatches *will* cause the overall verification task to fail (until the introduction of this feature, this was the default behaviour).
 
 While the provider build may pass, the verification results are still reported (if results publishing is enabled) to the Pact Broker as "failed", as the consumer should not be able to deploy the code that generated this contract.
 
-The pending property is _not_ used by the pact verification build that is triggered by the `contract_content_changed` webhook. This is because the pending status of the pact content is calculated based on the tags that the provider will use to publish the verification results, and the `contract_content_changed` webhook cannot know this information. The webhook triggered build is meant to be an "out of bound" build that does not have any dependencies on it, and it is expected to fail when pacts change.
+The pending property *is not used* by the pact verification build that is triggered by the `contract_requiring_verification_published` webhook, but should be set to `enablePending: true` for regular provider builds, as described above. This is because the pending status of the pact content is calculated based on the branch that the provider will use to publish the verification results, and the `contract_requiring_verification_published` event is triggered for the providers `HEAD` of the configured `mainBranch` property, and any deployed or released versions of the provider. The webhook triggered build is meant to be an "out of bound" build that does not have any dependencies on it, and it is expected to fail when pacts change. This is why it is essential to `enablePending:true` on builds where the Pact verification task, run when provider codebase changes.
+
+For those still using the deprecated `contract_content_changed` event.
+
+The pending property *is not used* by the pact verification build that is triggered by the `contract_content_changed` webhook. This is because the pending status of the pact content is calculated based on the branch that the provider will use to publish the verification results, and the `contract_content_changed` webhook cannot know this information. The webhook triggered build is meant to be an "out of bound" build that does not have any dependencies on it, and it is expected to fail when pacts change.
 
 ### WIP pacts
 
 [Work in progress pacts](/pact_broker/advanced_topics/wip_pacts) always have the pending flag set to true.
 
-## Examples
+## Examples with branches
 
 Let's walk through the "pending" lifecycle of a particular pact content version with an interaction that is implemented directly on the `main` branch of a provider.
 
-1. Provider is configured to verify the pacts with tags `main` and `production`, AND the `enablePending` option is set to true. The `main` branch of the provider is currently verifying both of those pacts successfully.
-1. Consumer publishes a new pact with tag `main` that has a new unsupported interaction in it.
-1. Next time the provider build runs, the `main` pact is returned for verification with `pending: true`. The verification fails. The status is reported back to the Pact Broker as failed, but the verification task does not exit with an error. Provider is able to deploy to production because the `production` pact passed.
-1. Provider implements the new feature on the `main` branch, and when the pipeline runs, the `main` pact passes, and a successful verification from the `main` branch of the provider is published. This successful verification means this pact content will now be `pending: false` for all future verifications by the `main` branch.
-1. Next time the provider pipeline runs, the `main` pact is returned for verification with `pending: false`. The verification for the `main` pact still passes, so everything is still green.
-1. A regression is made in the provider, and when the pipeline runs, the `main` pact is again returned for verification with `pending: false`. This time, when the verification fails, the verification task exits with an error, and the provider cannot deploy, as they have introduced a bug that breaks a previously supported pact.
+1. Provider is configured to verify the pacts with following consumer version selectors.
+   1. `{ mainBranch: true }` and `{ deployedOrReleased: true }`,
+   2. `enablePending` option is set to `false`.
+2. Provider build runs, both retrieved pacts (the consumers `main` branch pact, and the consumer pact deployed to `production`) are currently passing verification from the `main` branch of the provider.
+3. Consumer publishes a new pact with for the branch `main` that has a new unsupported interaction in it.
+4. Next time the provider build runs, the `main` pact is returned for verification with `pending: true`.
+   1. The verification fails. The status is reported back to the Pact Broker as failed, but the verification task does not exit with an error.
+   2. Provider is able to deploy to production because the `production` pact passed.
+5. Provider implements the new feature on the `main` branch
+   1. When the pipeline runs, the `main` pact passes
+   2. A successful verification from the `main` branch of the provider is published.
+   3. This successful verification means this pact content will now be `pending: false` for all future verifications by the `main` branch.
+6. Next time the provider pipeline runs, the `main` pact is returned for verification with `pending: false`.
+   1. The verification for the `main` pact still passes, so everything is still green.
+7. A regression is made in the provider, and when the pipeline runs, the `main` pact is again returned for verification with `pending: false`.
+   1. This time, when the verification fails, the verification task exits with an error, and the provider cannot deploy, as they have introduced a bug that breaks a previously supported pact.
 
 This time, let's walk through the lifecycle of a pact content version with an interaction that is implemented on the branch of a provider.
 
-1. (As above) Provider is configured to verify the pacts with tags `main` and `production`, AND the `enablePending` option is set to true. The `main` branch of the provider is currently verifying both of those pacts successfully.
-1. (As above) Consumer publishes a new pact with tag `main` that has a new unsupported interaction in it.
-1. (As above) Next time the provider build runs, the `main` pact is returned for verification with `pending: true`. The verification fails. The status is reported back to the Pact Broker as failed, but the verification task does not exit with an error. Provider is able to deploy to production because the `production` pact passed.
-1. Provider implements the new feature _on a feature branch_, `feat-x`, and when the pipeline runs, the `main` pact passes, and a successful verification from the `feat-x` branch of the provider is published. This successful verification means this pact content will now be `pending: false` for all future verifications by the `feat-x` branch.
-1. Next time the `feat-x` provider pipeline runs, the `main` pact is returned for verification with `pending: false`. Any verification failures for that content from now on will cause the `feat-x` build to fail.
-1. Next time the `main` provider pipeline runs, the `main` pact is still returned for verification with `pending: true`, because the `main` branch of the provider has still not verified the `main` pact yet.
-1. The `feat-x` branch is merged into `main`, and a successful verification for the `main` pact is published. This successful verification means this pact content will now be `pending: false` for all future verifications by the `main` branch, and any verification failures will break the build.
+1. (As above) Provider is configured to verify the pacts with following consumer version selectors.
+   1. `{ mainBranch: true }` and `{ deployedOrReleased: true }`,
+   2. `enablePending` option is set to `false`.
+2. (As above) Provider build runs, both retrieved pacts (the consumers `main` branch pact, and the consumer pact deployed to `production`) are currently passing verification from the `main` branch of the provider.
+3. (As above) Consumer publishes a new pact with branch `main` that has a new unsupported interaction in it.
+4. (As above) Next time the provider build runs, the `main` pact is returned for verification with `pending: true`.
+   1. The verification fails. The status is reported back to the Pact Broker as failed, but the verification task does not exit with an error.
+   2. Provider is able to deploy to production because the `production` pact passed.
+5. Provider implements the new feature *on a feature branch*, `feat-x`
+   1. When the pipeline runs, the `main` pact passes
+   2. A successful verification from the `feat-x` branch of the provider is published.
+   3. This successful verification means this pact content will now be `pending: false` for all future verifications by the `feat-x` branch.
+6. Next time the `feat-x` provider pipeline runs, the `main` pact is returned for verification with `pending: false`.
+   1. Any verification failures for that content from now on will cause the `feat-x` build to fail.
+7. Next time the `main` provider pipeline runs, the `main` pact is still returned for verification with `pending: true`.
+   1. This is because the `main` branch of the provider has still not verified the `main` pact yet.
+8. The `feat-x` branch is merged into `main`, and a successful verification for the `main` pact is published.
+   1. This successful verification means this pact content will now be `pending: false` for all future verifications by the `main` branch, and any verification failures will break the build.
 
 ## To start using the Pending pacts feature
 
@@ -125,13 +170,17 @@ This is the way it's meant to work. The pending flag doesn't make the failing ve
 
 ### Why has my master build suddenly failed when a successful verification was published from a branch?
 
-The pending flag is calculated based on the provider tags supplied. You probably haven't configured a provider tag, so the results from the branch and master can't be differentiated.
+The pending flag is calculated based on the provider branch property supplied. You probably haven't configured a provider branch in the providers verification setup options, so the results from the branch and master can't be differentiated.
+
+### Why is the pending configuration not working for my `contract_requiring_verification_published` webhook triggered build?
+
+The pending feature is only applicable to the [provider changed workflow](/pact_nirvana/step_4#d-configure-pact-to-be-verified-when-provider-changes), where the list of pacts to be verified are fetched from the Pact Broker. It does not apply to the [contract changed](/pact_nirvana/step_4#e-configure-pact-to-be-verified-when-contract-changes) workflow where the pact URL, provider branch and commit sha is passed to the job via the webhook, for each of the providers configured `mainBranch` and any `deployedOrReleased` versions. This is because the pending status of the pact content is calculated based on the branch property that the provider will use to publish the verification results, and the `contract_requiring_verification_published` webhook cannot know this information. The webhook triggered build is meant to be an "out of bound" build that does not have any dependencies on it, and it is expected to fail when pacts change.
 
 ### Why is the pending configuration not working for my `contract_content_changed` webhook triggered build?
 
-The pending feature is only applicable to the [provider changed workflow](/pact_nirvana/step_4#d-configure-pact-to-be-verified-when-provider-changes), where the list of pacts to be verified are fetched from the Pact Broker. It does not apply to the [contract changed](/pact_nirvana/step_4#e-configure-pact-to-be-verified-when-contract-changes) workflow where the pact URL is passed to the job via the webhook. This is because the pending status of the pact content is calculated based on the tags that the provider will use to publish the verification results, and the `contract_content_changed` webhook cannot know this information. The webhook triggered build is meant to be an "out of bound" build that does not have any dependencies on it, and it is expected to fail when pacts change.
+The pending feature is only applicable to the [provider changed workflow](/pact_nirvana/step_4#d-configure-pact-to-be-verified-when-provider-changes), where the list of pacts to be verified are fetched from the Pact Broker. It does not apply to the [contract changed](/pact_nirvana/step_4#e-configure-pact-to-be-verified-when-contract-changes) workflow where the pact URL is passed to the job via the webhook. This is because the pending status of the pact content is calculated based on the branch property that the provider will use to publish the verification results, and the `contract_content_changed` webhook cannot know this information. The webhook triggered build is meant to be an "out of bound" build that does not have any dependencies on it, and it is expected to fail when pacts change.
 
-### I'm so confused by the whole thing!
+### I'm so confused by the whole thing
 
 The API that returns the list of pacts to verify has some built in messaging to explain what is going on that should be displayed to the user. Here is an example from the Ruby implementation.
 
@@ -140,14 +189,14 @@ DEBUG: The pact at https://test.pactflow.io/pacts/provider/Bar/consumer/Foo/pact
 is being verified because it matches the following configured selection criterion:
 latest pact between a consumer and Bar
 DEBUG: This pact is in pending state for this version of Bar because a successful verification
-result for a version of Bar with tag 'master' has not yet been published.
+result for a version of Bar with branch 'master' has not yet been published.
 If this verification fails, it will not cause the overall build to fail.
 Read more at https://pact.io/pending
 
 [test output]
 
-DEBUG: This pact is still in pending state for any version of Bar with tag 'master' as a successful
-verification result with this tag has not yet been published
+DEBUG: This pact is still in pending state for any version of Bar with branch 'master' as a successful
+verification result with this branch has not yet been published
 ```
 
 If you cannot see this debug output, please consult the documentation for your language to see if you can find a way to turn it on. If you can't find that, please hop on to our [Slack workspace](https://slack.pact.io) and ask about it in the appropriate channel for your language.

--- a/website/docs/pact_broker/advanced_topics/wip_pacts.md
+++ b/website/docs/pact_broker/advanced_topics/wip_pacts.md
@@ -32,7 +32,7 @@ __NOTE:__ If you are using `tags` then set the `provider version tag` which is r
 The logic for what constitutes a WIP pact is actually quite complex! To make it work as a human would intuitively expect involves many rules. It might be easiest to explain how the pacts are selected by stepping through it procedurally as the code does.
 
 1. Find all the pacts that are the latest for their branch (the "head" pacts). (eg. The latest pact for a version associated with branch `main` + the latest pact for a version with branch `feat-x` + the latest pact for a version with branch `feat-y` ...)
-2. Discard the pacts that have been explicitly selected in the consumerVersionSelectors. (eg. usually you'd configure the consumer version selectors with `{ "mainBranch" : true }` / `{"tag": "main", "latest": "true"}`, so discard the latest `main` branch pact)
+2. Discard the pacts that have been explicitly selected in the consumerVersionSelectors. (eg. usually you'd configure the consumer version selectors with `{ "mainBranch" : true }` or if using tags `{"tag": "main", "latest": "true"}`, so discard the latest `main` branch pact)
 3. Discard all the pacts created before the `includeWipPactsSince` date (we don't want to verify every unverified head pact since the dawn of time).
 4. Discard all the pacts that have a successful verification by a provider version with a different configured branch before this branch was created (this is so that if you create a brand new provider branch, you don't get EVERY head pact included in the WIP pacts list).
 5. Discard all the pacts that have a successful verification by a provider version with the same configured branch (or tag) _where the pact content was explicitly specified in the selectors_.


### PR DESCRIPTION
- Updates Pending pacts page to reference branches, and new consumer version selectors
  - https://deploy-preview-178--docs-pact-io.netlify.app/pact_broker/advanced_topics/pending_pacts
- Updates consumer version selector page code snippets to support branches/environments
  - https://deploy-preview-178--docs-pact-io.netlify.app/pact_broker/advanced_topics/consumer_version_selectors#code-examples-with-branches
- Adds links to source code/docs for respective language implementations
  - https://deploy-preview-178--docs-pact-io.netlify.app/pact_broker/advanced_topics/consumer_version_selectors#docs