### PR TITLE
Update books.md

### DIFF
--- a/website/docs/books.md
+++ b/website/docs/books.md
@@ -5,5 +5,5 @@ title: Books
 We're not aware of any books currently dedicated to contract testing, but here are some that talk about Pact and contract testing as part of a broader microservices development and testing strategy:
 
 * [Building Microservices](https://samnewman.io/books/)
-* [Testing in Brief: Using Hoverfly, Pact, and Containers](https://www.amazon.com/-/es/Alex-Soto-Bueno/dp/1617292893/ref=sr_1_fkmr1_1?__mk_es_US=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dchild=1&keywords=microservices+testing+in+brief&qid=1600348080&s=books&sr=1-1-fkmr1)
+* [Testing in Brief: Using Hoverfly, Pact, and Containers](https://www.amazon.com/Microservices-Testing-Brief-Hoverfly-Containers-ebook/dp/B0876N9SP6)
 * [Testing Java Microservices: Using Arquillian, Hoverfly, AssertJ, JUnit, Selenium, and Mockito](https://www.amazon.com/-/es/Alex-Soto-Bueno/dp/1617292893/ref=sr_1_fkmr1_1?__mk_es_US=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dchild=1&keywords=microservices+testing+in+brief&qid=1600348080&s=books&sr=1-1-fkmr1)

--- a/website/docs/books.md
+++ b/website/docs/books.md
@@ -6,4 +6,4 @@ We're not aware of any books currently dedicated to contract testing, but here a
 
 * [Building Microservices](https://samnewman.io/books/)
 * [Testing in Brief: Using Hoverfly, Pact, and Containers](https://www.amazon.com/Microservices-Testing-Brief-Hoverfly-Containers-ebook/dp/B0876N9SP6)
-* [Testing Java Microservices: Using Arquillian, Hoverfly, AssertJ, JUnit, Selenium, and Mockito](https://www.amazon.com/-/es/Alex-Soto-Bueno/dp/1617292893/ref=sr_1_fkmr1_1?__mk_es_US=%C3%85M%C3%85%C5%BD%C3%95%C3%91&dchild=1&keywords=microservices+testing+in+brief&qid=1600348080&s=books&sr=1-1-fkmr1)
+* [Testing Java Microservices: Using Arquillian, Hoverfly, AssertJ, JUnit, Selenium, and Mockito](https://www.amazon.com/Alex-Soto-Bueno/dp/1617292893)


### PR DESCRIPTION
Fixes a duplicated link, The second link was pointing to the same url as the third, I think it was meant to be pointing to this other book on Amazon instead.

I've also cleaned up unnecessary HTML parameters from the second link.