### PR TITLE
Update gradle.md and maven.md

### DIFF
--- a/website/docs/implementation_guides/jvm/provider/gradle.md
+++ b/website/docs/implementation_guides/jvm/provider/gradle.md
@@ -819,7 +819,7 @@ pact {
 **NOTE:** you can't use the `url` function with S3 URLs, as the URL and URI classes from the Java SDK
  don't support URLs with the s3 scheme.
 
-# Publishing pact files to a pact broker
+## Publishing pact files to a pact broker
 
 **NOTE**: There is a pact CLI that can be used to publish pacts. See https://github.com/pact-foundation/pact-ruby-cli.
 

--- a/website/docs/implementation_guides/jvm/provider/maven.md
+++ b/website/docs/implementation_guides/jvm/provider/maven.md
@@ -870,7 +870,7 @@ By default, the test classpath is scanned for annotated methods. You can overrid
 </plugin>
 ```
 
-# Publishing pact files to a pact broker
+## Publishing pact files to a pact broker
 
 **NOTE**: There is also a pact CLI that can be used to publish pacts. See https://github.com/pact-foundation/pact-ruby-cli.
 


### PR DESCRIPTION
Changes the hierarchy level of two headings to conform to other headings. If I understand it right, this should make the headings linkable because an href will be generated.