### PR TITLE
wiki: Pactman does not support message queues

### DIFF
--- a/website/docs/implementation_guides/python.md
+++ b/website/docs/implementation_guides/python.md
@@ -4,7 +4,7 @@ title: Overview
 
 [Pact Python](https://github.com/pact-foundation/pact-python/) is currently in active development and supports Pact Specification v2, [pending pacts][pending], and [WIP pacts][wip].
 
-[Pactman](https://github.com/reecetech/pactman) is another Python implementation of Pact, which is not officially supported by the core Pact Foundation team. It is in maintenance mode, and supports Pact Specification v3. It has a more idiomatic Python interface as it is pure Python and doesn't wrap the [pact-ruby-standalone CLI][pact-ruby-standalone], however it does not support [pending][pending] or [WIP pacts][wip].
+[Pactman](https://github.com/reecetech/pactman) is another Python implementation of Pact, which is not officially supported by the core Pact Foundation team. It is in maintenance mode, and supports Pact Specification v3. It has a more idiomatic Python interface as it is pure Python and doesn't wrap the [pact-ruby-standalone CLI][pact-ruby-standalone], however it does not support [pending][pending], [WIP pacts][wip], or [message queue](https://docs.pact.io/implementation_guides/pact_specification#specification-documentation).
 
 [pending]: https://docs.pact.io/pending
 [wip]: https://docs.pact.io/wip


### PR DESCRIPTION
One of the main changes in pact v3 was the addition of the message queue format; users should be informed as soon as possible that Pactman is not a viable solution for validating message queue pacts, rather than wading through github issues like I had to do. 

https://github.com/reecetech/pactman/issues/68