### PR TITLE
chore: update contribution guidelines to include conventional commit …

### DIFF
--- a/website/docs/contributing/code.md
+++ b/website/docs/contributing/code.md
@@ -7,9 +7,34 @@ We encourage contribution to any of our libraries, if you see something that sho
 
 1. Fork it
 2. Create your feature branch \(`git checkout -b my-new-feature`\)
-3. Commit your changes \(`git commit -am 'Add some feature'`\)
+3. Commit your changes \(`git commit -am 'feat: Add some feature'`\)
 4. Push to the branch \(`git push origin my-new-feature`\)
 5. Create new Pull Request
+
+## Commit messages
+
+Pact Libraries tend to use the [Conventional Changelog](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md) commit message conventions to simplify automation process. Please ensure you follow the guidelines.
+
+You can take a look at the git history (git log) to get the gist of it. If you have questions, feel free to reach out in in our [slack community](https://pact-foundation.slack.com/).
+
+### Release notes
+
+Commit messages with `fix` or `feat` prefixes will appear in the release notes. These communicate changes that users may want to know about.
+
+- `feat(<scope>):` or `feat:` messages appear under "New Features", and trigger minor version bumps.
+- `fix(<scope>):` or `fix:` messages appear under "Fixes and improvements", and trigger patch version bumps.
+
+If your commit message introduces a breaking change, please include a footer that starts with `BREAKING CHANGE:`. For more information, please see the [Conventional Changelog](https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md) guidelines.
+
+(Also, if you are committing breaking changes, you may want to check with the other maintainers on slack first).
+
+- Examples of `fix` include bug fixes and dependency bumps that users of the pact library may want to know about.
+
+- Examples of `feat` include new features and substantial modifications to existing features.
+
+- Examples of things that we'd prefer not to appear in the release notes include documentation updates, modified or new examples, refactorings, new tests, etc. We usually use one of chore, style, refactor, or test as appropriate.
+
+## New Features
 
 If you would like to see a bigger feature, or see `Pact` implemented in another language, please check out the [Pact specification](https://github.com/pact-foundation/pact-specification) and have a chat to one of us on the Pact Slack workspace ([signup](https://slack.pact.io)|[login](https://pact-foundation.slack.com)).
 


### PR DESCRIPTION
…detail

We were missing this, and in some repos we don't have contributing guidelines, so we have to sometimes ask for commits to be amended

https://github.com/pact-foundation/pact-broker-docker/pull/184

I believe conventional commit is used is most of the repos and if not is pretty sensible enough to be accepted. 