### PR TITLE
docs(workshops.md): Link more recent version of the .NET workshop

### DIFF
--- a/website/docs/implementation_guides/workshops.md
+++ b/website/docs/implementation_guides/workshops.md
@@ -29,7 +29,7 @@ These hands-on labs walk you through an example problem from start to finish, ex
 * [JVM - Gradle/Junit4/Springboot](https://github.com/pact-foundation/pact-workshop-jvm-spring)
 * [JVM - Maven/Junit5/Springboot](https://github.com/pact-foundation/pact-workshop-Maven-Springboot-JUnit5)
 * [Android](https://github.com/DiUS/pact-workshop-android)
-* [.NET](https://github.com/pactflow/pact-workshop-dotnet-core-v1)
+* [.NET](https://github.com/pact-foundation/pact-workshop-dotnet)
 * [CI/CD](https://docs.pactflow.io/docs/workshops/ci-cd)
 
 ## Examples


### PR DESCRIPTION
* Link the version of .NET workshop that aligns with the other workshops

Why?
* I recently wanted to learn more about pact and followed the workshop linked originally
  * Only after running into some issues I found out that there is a more recent version
* Aligns .NET workshop contents with workshops in other languages