### PR TITLE
fix typo in pact_nirvana.md

### DIFF
--- a/website/docs/pact_nirvana.md
+++ b/website/docs/pact_nirvana.md
@@ -17,7 +17,7 @@ For a complete hands-on workshop implementing the steps in this guide with GitHu
 
 ### How to use this document
 
-Each integration is different. Each organisation has different history and culture, and each team   y have different processes for development, testing, and deployment. Each of these differences affect the best choices for Pact workflow.
+Each integration is different. Each organisation has different history and culture, and each team may have different processes for development, testing, and deployment. Each of these differences affect the best choices for Pact workflow.
 
 However, there are many similarities in the steps necessary on the journey to a full-featured and effective Pact setup \(_"Pact Nirvana"_\). This document describes those steps.
 


### PR DESCRIPTION
It seems like something got a little jumbled in the text for this page.
I'm pretty sure the intended word here was **may**, but what was rendered was a solitary `y`.

```diff
- each team   y have different processes
+ each team may have different processes
```