### PR TITLE
Update 13_Step13.md

### DIFF
--- a/website/docs/university/introduction/13_Step13.md
+++ b/website/docs/university/introduction/13_Step13.md
@@ -167,7 +167,7 @@ pactBrokerToken: process.env.PACT_BROKER_TOKEN || 'pact_workshop',
 Let's run the provider verification one last time after this change:
 
 ```console
-❯ npm run test:pact --prefix provider
+❯ CI=true npm run test:pact --prefix provider
 
 > product-service@1.0.0 test:pact /Users/you54f/dev/saf/dev/pact-workshop-clone/provider
 > npx jest --testTimeout 30000 --testMatch "**/*.pact.test.js"


### PR DESCRIPTION
On line 54, there is a condition to check to publish results only when it is run from CI. 

```
if (process.env.CI) {
            Object.assign(opts, {
                publishVerificationResult: true,
            });
        }
```

For this workshop, since users are running these commands from their local machines, this means that this block will be skipped. 

As someone completely new to PACT, it took me a while to figure this and add the flag CI=true to be able to publish results on PactFlow and complete the workshop.

Hence the PR.