### PR TITLE
docs: reflect pact-ruby-standalone rename to pact-standalone

### DIFF
--- a/website/docs/implementation_guides/overview.md
+++ b/website/docs/implementation_guides/overview.md
@@ -55,19 +55,19 @@ For full overview of the CLI tooling, see the [CLI tooling page](./cli).
 - ✅ Supported
 - 🗑 In retirement phase
 
-| Name                   | Status | Pact Spec  | Repo                          | Release                                                  |
-| ---------------------- | ------ | ---------- | ----------------------------- | -------------------------------------------------------- |
-| pact_mock_server_cli   | ✅     | v3         | [GitHub][mock-cli]            | [pact_mock_server-cli-releases][mock-cli-releases]                 |
-| pact_verifier_cli      | ✅     | v1.1 -> v4 | [GitHub][verifier-cli]        | [pact_verifier-cli-releases][verifier-cli-releases]         |
-| pact-stub-server       | ✅     | v4         | [GitHub][stub-cli]            | [pact-stub-server-cli-releases][stub-cli-releases]                 |
-| pact-plugin-cli        | ✅     | v4         | [GitHub][plugin-cli]          | [plugin-cli-releases][plugin-cli-releases]             |
-| pact-broker (client)   | ✅     | n/a        | [GitHub][broker-client-cli]   | [pact-ruby-standalone releases][pact-standalone-release] |
-| pactflow               | ✅     | n/a        | [GitHub][pactflow-client-cli] | [pact-ruby-standalone releases][pact-standalone-release] |
-| pact                   | 🗑     | n/a        | [GitHub][pact-cli]            | [pact-ruby-standalone releases][pact-standalone-release] |
-| pact-message           | 🗑     | v3         | [GitHub][message-cli-legacy]  | [pact-ruby-standalone releases][pact-standalone-release] |
-| pact-mock-service      | 🗑     | v1 -> v2   | [GitHub][mock-cli-legacy]     | [pact-ruby-standalone releases][pact-standalone-release] |
-| pact-provider-verifier | 🗑     | v1 -> v2   | [GitHub][verifier-cli-legacy] | [pact-ruby-standalone releases][pact-standalone-release] |
-| pact-stub-service      | 🗑     | v2         | [GitHub][stub-cli-legacy]     | [pact-ruby-standalone releases][pact-standalone-release] |
+| Name                   | Status | Pact Spec  | Repo                          | Release                                             |
+| ---------------------- | ------ | ---------- | ----------------------------- | --------------------------------------------------- |
+| pact_mock_server_cli   | ✅     | v3         | [GitHub][mock-cli]            | [pact_mock_server-cli-releases][mock-cli-releases]  |
+| pact_verifier_cli      | ✅     | v1.1 -> v4 | [GitHub][verifier-cli]        | [pact_verifier-cli-releases][verifier-cli-releases] |
+| pact-stub-server       | ✅     | v4         | [GitHub][stub-cli]            | [pact-stub-server-cli-releases][stub-cli-releases]  |
+| pact-plugin-cli        | ✅     | v4         | [GitHub][plugin-cli]          | [plugin-cli-releases][plugin-cli-releases]          |
+| pact-broker (client)   | ✅     | n/a        | [GitHub][broker-client-cli]   | [pact-standalone releases][pact-standalone-release] |
+| pactflow               | ✅     | n/a        | [GitHub][pactflow-client-cli] | [pact-standalone releases][pact-standalone-release] |
+| pact                   | 🗑     | n/a        | [GitHub][pact-cli]            | [pact-standalone releases][pact-standalone-release] |
+| pact-message           | 🗑     | v3         | [GitHub][message-cli-legacy]  | [pact-standalone releases][pact-standalone-release] |
+| pact-mock-service      | 🗑     | v1 -> v2   | [GitHub][mock-cli-legacy]     | [pact-standalone releases][pact-standalone-release] |
+| pact-provider-verifier | 🗑     | v1 -> v2   | [GitHub][verifier-cli-legacy] | [pact-standalone releases][pact-standalone-release] |
+| pact-stub-service      | 🗑     | v2         | [GitHub][stub-cli-legacy]     | [pact-standalone releases][pact-standalone-release] |
 
 [verifier-cli]: https://github.com/pact-foundation/pact-reference/tree/master/rust/pact_verifier_cli
 [stub-cli]: https://github.com/pact-foundation/pact-stub-server
@@ -85,7 +85,7 @@ For full overview of the CLI tooling, see the [CLI tooling page](./cli).
 [pactflow-client-cli]: https://github.com/pact-foundation/pact_broker-client?tab=readme-ov-file#provider-contracts-pactflow-only
 [pact-cli]: https://github.com/pact-foundation/pact-ruby/tree/master/lib/pact/cli
 [wrapper]: /wrapper_implementations
-[pact-standalone-release]: https://github.com/pact-foundation/pact-ruby-standalone/releases
+[pact-standalone-release]: https://github.com/pact-foundation/pact-standalone/releases
 
 ## Docker
 
@@ -99,13 +99,18 @@ For full overview of the CLI tooling, see the [CLI tooling page](./cli).
 | pact_mock_server_cli   | ✅     | [DockerHub][mock-cli-docker]     |                                         | [pact-reference][mock-cli-docker-repo]      |
 | pact_verifier_cli      | ✅     | [DockerHub][verifier-cli-docker] |                                         | [pact-reference][verifier-cli-docker-repo]  |
 | pact-stub-server       | ✅     | [DockerHub][stub-cli-docker]     |                                         | [pact-stub-server][stub-cli-docker-repo]    |
-| pact-broker (client)   | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
-| pactflow               | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
-| pact                   | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
-| pact-message           | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
-| pact-mock-service      | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
-| pact-provider-verifier | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
-| pact-stub-service      | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-ruby-cli][pact-cli-docker-repo]       |
+| pact (top level entry) | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-broker (client)   | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pactflow               | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact_mock_server_cli   | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact_verifier_cli      | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-stub-server       | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-plugin-cli        | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pactflow-ai            | ✅     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-message           | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-mock-service      | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-provider-verifier | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
+| pact-stub-service      | 🗑     | [DockerHub][pact-cli-docker]     | [GHCR][pact-cli-docker-github]          | [pact-docker-cli][pact-cli-docker-repo]       |
 
 [verifier-cli-docker]: https://hub.docker.com/r/pactfoundation/pact-ref-verifier
 [stub-cli-docker]: https://hub.docker.com/r/pactfoundation/pact-stub-server
@@ -128,13 +133,17 @@ For full overview of the CLI tooling, see the [CLI tooling page](./cli).
 | ---------------------- | ------ | --------------------- |
 | pact-broker (client)   | ✅     | [homebrew-standalone] |
 | pactflow               | ✅     | [homebrew-standalone] |
+| pact_mock_server_cli   | ✅     | [homebrew-standalone] |
+| pact_verifier_cli      | ✅     | [homebrew-standalone] |
+| pact-stub-server       | ✅     | [homebrew-standalone] |
+| pact-plugin-cli        | ✅     | [homebrew-standalone] |
 | pact                   | 🗑     | [homebrew-standalone] |
 | pact-message           | 🗑     | [homebrew-standalone] |
 | pact-mock-service      | 🗑     | [homebrew-standalone] |
 | pact-provider-verifier | 🗑     | [homebrew-standalone] |
 | pact-stub-service      | 🗑     | [homebrew-standalone] |
 
-[homebrew-standalone]: https://github.com/pact-foundation/homebrew-pact-ruby-standalone
+[homebrew-standalone]: https://github.com/pact-foundation/homebrew-pact-standalone
 
 ###  Homebrew Supported Platforms
 


### PR DESCRIPTION
update tooling table to reflect supported rust tooling now included in pact-docker-cli (formerly pact-ruby-cli) and pact-standalone (formerly pact-ruby-standalone)

TODO:

- [ ] Update command line tools overview 
  - https://docs.pact.io/implementation_guides/cli