### PR TITLE
docs: create an recipe for optional fields

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -52,6 +52,10 @@ Pact was written by a team that was using microservices that had read/write REST
 
 ### Why is there no support for specifying optional attributes?
 
+:::note
+Refer to our [guide](/recipes/optional) on handling optional values.
+:::
+
 Firstly, it is assumed that you have control over the provider's data \(and consumer's data\) when doing the verification tests. If you don't, then maybe Pact is [not the best tool for your situation](/getting_started/what_is_pact_good_for).
 
 Secondly, if Pact supports making an assertion that element `$.body.name` may be present in a response, then you write consumer code that can handle an optional `$.body.name`, but in fact, the provider gives `$.body.firstname`, no test will ever fail to tell you that you've made an incorrect assumption. Remember that a provider may return extra data without failing the contract, but it must provide at minimum the data you expect.

--- a/website/docs/recipes.md
+++ b/website/docs/recipes.md
@@ -8,6 +8,7 @@ Recipes and pre-built integrations to test common scenarios in Pact
 
 | Recipe/Integration                                     | Description                                                                                                                         |
 | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| [Optional Fields](/recipes/optional)                             | How to test payloads with optional fields                                                                      |
 | [GraphQL](/recipes/graphql)                             | Strategies for testing GraphQL endpoints (example with Apollo)                                                                      |
 | [API Gateway](/recipes/apigateway)                      | Strategies for dealing with API Gateways, such as AWS API Gateway, Kong etc.                                                        |
 | [AWS Signed Requests](/recipes/awssignedrequests)                      | How to test services AWS services that use [signed requests](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-signing.html)                                                        |

--- a/website/docs/recipes/optional.md
+++ b/website/docs/recipes/optional.md
@@ -1,0 +1,191 @@
+---
+title: Optional Fields
+description: Strategies for handling optional values in API responses when using Pact.
+---
+
+## Problem Statement
+
+Optional values in API responses are a common challenge when using Pact because there is no [optional matcher](/faq#why-is-there-no-support-for-specifying-optional-attributes). You cannot define something like `stringOrNull(...)` to represent this schema:
+
+```yaml
+components:
+  schemas:
+    User:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: number
+        lastLogin:     # Optional field
+          type: string
+          format: date
+```
+
+For example, consider an API that responds to `GET /users/{id}` with the following payloads:
+
+Before login:
+```json
+{
+  "id": "123",
+  "lastLogin": null
+}
+```
+
+After login:
+```json
+{
+  "id": "456",
+  "lastLogin": "2025-10-20"
+}
+```
+
+Or, a list that includes both variants:
+```json
+{
+  "users": [
+    { "id": "123", "lastLogin": null },
+    { "id": "456", "lastLogin": "2025-10-20" }
+  ]
+}
+```
+
+You cannot use an "each like" matcher here, because the array contains objects with different shapes.
+
+## Solution
+
+There are two primary ways to handle optional values:
+
+1. **Provider States:** Define specific provider states for each variant.
+2. **Array Contains Matcher:** Use the "Array Contains" matcher (introduced in the [V4 specification](https://github.com/pact-foundation/pact-specification/tree/version-4)) to validate multiple object shapes.
+
+### 1. Provider States
+
+Use provider states to vary the data returned by the provider, ensuring each test scenario represents a consistent state.
+
+#### Consumer Implementation
+
+In your consumer tests, define multiple interactions—typically a "minimum" and "maximum" version of the object—rather than every possible combination.
+
+```js
+describe('GET /users/{id}', () => {
+  it('returns a user with lastLogin', async () => {
+    await pact
+      .addInteraction()
+      .given('user 1 has previously logged in')
+      .uponReceiving('a request to get a user')
+      .withRequest('GET', '/users/1')
+      .willRespondWith(200, (builder) => {
+        builder.jsonBody({
+          id: "1",
+          lastLogin: "2025-10-20"
+        });
+      })
+      .executeTest(async (mockserver) => {
+        const client = new UserService(mockserver.url);
+        const user = await client.getUser(1);
+        expect(user).to.deep.equal({
+          id: "1",
+          lastLogin: "2025-10-20"
+        });
+      });
+  });
+
+  it('returns a user without lastLogin', async () => {
+    await pact
+      .addInteraction()
+      .given('user 1 has not previously logged in')
+      .uponReceiving('a request to get a user')
+      .withRequest('GET', '/users/1')
+      .willRespondWith(200, (builder) => {
+        builder.jsonBody({ id: "1" });
+      })
+      .executeTest(async (mockserver) => {
+        const client = new UserService(mockserver.url);
+        const user = await client.getUser(1);
+        expect(user).to.deep.equal({ id: "1" });
+      });
+  });
+});
+```
+
+#### Provider Implementation
+
+On the provider side, configure your state handlers to set up the correct data for each scenario.
+
+```js
+const stateHandlers = {
+  "user 1 has previously logged in": () => {
+    userRepository.set("1", new User("Bill", "2025-10-20"));
+    return Promise.resolve();
+  },
+  "user 1 has not previously logged in": () => {
+    userRepository.set("1", new User("Bill", null));
+    return Promise.resolve();
+  },
+};
+```
+
+This approach ensures that your provider behaves consistently across tests.
+
+### 2. Array Contains Matcher
+
+When working with lists that contain objects of different shapes, configuring provider states can be difficult. In these cases, use the "Array Contains" matcher to verify that all expected object variants appear in the provider's response.
+
+During verification, Pact checks that each expected variant defined in the consumer test is present in the actual provider response. The test passes only if *all* expected variants are found. Any additional objects in the response that do not match one of the expected variants are ignored.
+
+#### Consumer Implementation
+
+In Pact JS, use the `arrayContaining` matcher:
+
+```js
+describe('GET /users', () => {
+  it('returns multiple users in various states', async () => {
+    await pact
+      .addInteraction()
+      .uponReceiving('a request for users with various lastLogin states')
+      .withRequest('GET', '/users')
+      .willRespondWith(200, (builder) => {
+        builder.jsonBody({
+          users: Matchers.arrayContaining(
+            Matchers.like({ id: '123', lastLogin: null }),
+            Matchers.like({ id: '456', lastLogin: "2025-10-20" })
+          ),
+        });
+      })
+      .executeTest(async (mockserver) => {
+        const client = new UserService(mockserver.url);
+        const users = await client.getUsers();
+        expect(users[0]).to.deep.equal({
+          id: '123',
+          lastLogin: null
+        });
+      });
+  });
+});
+```
+
+#### Provider Implementation
+
+On the provider side, ensure the response contains the expected variants. Extra objects are ignored by the Pact verification process.
+
+```js
+server.get('/users', (req, res) => {
+  res.json({
+    users: [
+      { id: '123', lastLogin: "2025-10-20" },
+      { id: '456', lastLogin: null },
+      { another: 'object', completely: 'different', yes: false }
+    ]
+  });
+});
+```
+
+---
+
+## Summary
+
+- Use **Provider States** when you can easily control data setup for each scenario.
+- Use **Array Contains Matchers** for collections with varying shapes that are difficult to preconfigure.
+- Test the "minimum" and "maximum" versions of each object to reduce redundancy and improve maintainability.
+

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -335,6 +335,7 @@
     ],
     "Recipes": [
       "recipes",
+      "recipes/optional",
       "recipes/kafka",
       "recipes/graphql",
       "recipes/apigateway",


### PR DESCRIPTION
Whilst we have an FAQ on why we don't have optional fields, we lack a useful guide explaining how to address them.

This is a first attempt at that guide (added to the "recipes" section).