### PR TITLE
docs: add docs on pactflow skill and mcp changes

### DIFF
--- a/website/docs/ai_tools/pactflow-skill.md
+++ b/website/docs/ai_tools/pactflow-skill.md
@@ -1,0 +1,791 @@
+---
+title: PactFlow AI Assistant Skill
+sidebar_label: PactFlow Skill
+---
+
+# PactFlow AI Assistant Skill
+
+The **PactFlow skill** turns your AI coding assistant into a PactFlow and Pact contract testing expert. It provides deep knowledge of consumer test patterns, provider verification configuration, can-i-deploy diagnostics, and full workspace management — surfaced directly in your editor without leaving your flow.
+
+It ships as part of the [`swagger-contract-testing`](https://github.com/pactflow/pactflow-agent-skills) plugin alongside two companion skills: **Drift** (OpenAPI contract testing) and **OpenAPI Parser** (spec analysis).
+
+---
+
+## Skill vs Pact CLI vs Full Plugin
+
+There are three levels of capability depending on what is installed alongside the skill.
+
+|                                                     | Skill only | Skill + Pact CLI | Full plugin (skill + MCP server) |
+| --------------------------------------------------- | ---------- | ---------------- | -------------------------------- |
+| Pact/PactFlow domain knowledge                      | Yes        | Yes              | Yes                              |
+| Writes consumer tests and verification config       | Yes        | Yes              | Yes                              |
+| Debugs can-i-deploy failures conceptually           | Yes        | Yes              | Yes                              |
+| Connects to your actual broker                      | No         | Yes              | Yes                              |
+| Publishes pacts and records deployments             | No         | Yes              | Yes                              |
+| Runs can-i-deploy against live data                 | No         | Yes              | Yes                              |
+| Lists pacticipants, environments, branches          | No         | Yes              | Yes                              |
+| Manages webhooks and environments                   | No         | Yes              | Yes                              |
+| Queries the contract matrix directly                | No         | No               | Yes                              |
+| Generates tests using your existing provider states | No         | No               | Yes                              |
+| AI-assisted test generation (PactFlow Cloud)        | No         | No               | Yes                              |
+| AI-assisted test review (PactFlow Cloud)            | No         | No               | Yes                              |
+| BDCT cross-contract verification results            | No         | No               | Yes                              |
+
+**Skill only** — the assistant has expert knowledge but cannot reach your broker. Useful for writing tests from scratch or working through problems offline.
+
+**Skill + Pact CLI** — with the `pact-broker` CLI installed and broker credentials set in the environment, the skill can run shell commands via the Bash tool to publish pacts, run can-i-deploy, record deployments, manage environments and webhooks, and more. This works with both PactFlow Cloud and open-source Pact Broker, and requires no MCP configuration.
+
+**Full plugin (skill + MCP server)** — the [SmartBear MCP server](./smartbear-mcp.md) exposes `contract-testing_*` tools that go beyond what the CLI supports: direct matrix queries, AI-assisted test generation and review using your live provider states, BDCT cross-contract verification results, and structured access to every broker resource. This is the recommended setup for the richest experience.
+
+:::note Pact Plugin Framework
+The word "plugin" in this context refers to an AI coding assistant plugin — a bundle of skills and agents for your IDE. It is unrelated to the [Pact Plugin Framework](/plugins/quick_start), which extends Pact with new transports and protocols (gRPC, Protobuf, etc.).
+:::
+
+---
+
+## Installing in Claude Code
+
+Claude Code supports plugins via a marketplace system (requires Claude Code v1.0.33+). Installing the plugin gives you both the skill and the MCP server automatically.
+
+### 1. Add the marketplace
+
+Inside a Claude Code session:
+
+```
+/plugin marketplace add pactflow/pactflow-agent-skills
+```
+
+Or add it to `.claude/settings.json` so teammates are prompted to install it when they open the project:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "pactflow-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "pactflow/pactflow-agent-skills"
+      }
+    }
+  }
+}
+```
+
+### 2. Install the plugin
+
+```
+/plugin install swagger-contract-testing@pactflow-agent-skills
+```
+
+**Scope options:**
+
+| Scope            | Stored in                     | Who it applies to                       |
+| ---------------- | ----------------------------- | --------------------------------------- |
+| `user` (default) | `~/.claude/settings.json`     | You, across all projects                |
+| `project`        | `.claude/settings.json`       | Everyone on the team (commit this file) |
+| `local`          | `.claude/settings.local.json` | You, in this project only (gitignored)  |
+
+### 3. Configure PactFlow credentials
+
+Add a `pluginConfigs` block to `~/.claude/settings.json`:
+
+```json
+{
+  "pluginConfigs": {
+    "swagger-contract-testing@pactflow-agent-skills": {
+      "options": {
+        "pact_broker_base_url": "https://yourorg.pactflow.io",
+        "pact_broker_token": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+Get your API token from `https://yourorg.pactflow.io/settings/api-tokens`.
+
+For an open-source Pact Broker, use `pact_broker_username` and `pact_broker_password` instead of `pact_broker_token`.
+
+### 4. Reload
+
+```
+/reload-plugins
+```
+
+### Managing the plugin
+
+```
+/plugin                          # open plugin manager
+/reload-plugins                  # reload without restarting
+/plugin disable swagger-contract-testing@pactflow-agent-skills
+/plugin uninstall swagger-contract-testing@pactflow-agent-skills
+```
+
+---
+
+## Installing the skill only (other AI tools)
+
+If you are using Cursor, Windsurf, GitHub Copilot, Codex, Kiro, or OpenCode, install the skill files directly. You will get domain knowledge but no live broker connection. To add the live connection, configure the [SmartBear MCP server](#adding-a-live-broker-connection) separately.
+
+### Prerequisites
+
+Clone or download the repository:
+
+```bash
+git clone https://github.com/pactflow/pactflow-agent-skills.git
+```
+
+The skill files live at `plugins/swagger-contract-testing/skills/pactflow/`.
+
+### GitHub Copilot (VS Code)
+
+Copy the skill into a discovery location Copilot checks automatically:
+
+```bash
+# .github/skills (most common for GitHub projects)
+mkdir -p .github/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow .github/skills/pactflow
+```
+
+Commit `.github/skills/` to share the skill with your team. No VS Code configuration required.
+
+For a personal install across all your projects:
+
+```bash
+mkdir -p ~/.copilot/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow ~/.copilot/skills/pactflow
+```
+
+### Cursor
+
+```bash
+# Project-level (commit to share with team)
+mkdir -p .cursor/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow .cursor/skills/pactflow
+
+# Global (all your projects)
+mkdir -p ~/.cursor/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow ~/.cursor/skills/pactflow
+```
+
+You can also import from GitHub directly: open **Cursor Settings → Rules → Add Rule → Remote Rule (GitHub)** and point it at `https://github.com/pactflow/pactflow-agent-skills/tree/main/plugins/swagger-contract-testing/skills/pactflow`.
+
+### Windsurf
+
+```bash
+# Project-level (commit to share with team)
+mkdir -p .windsurf/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow .windsurf/skills/pactflow
+
+# Global (all your projects)
+mkdir -p ~/.codeium/windsurf/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow ~/.codeium/windsurf/skills/pactflow
+```
+
+Or use the UI: open the **Cascade** panel → **⋯ menu → Skills → + Workspace** or **+ Global**.
+
+### OpenCode
+
+```bash
+# Global
+cp -r plugins/swagger-contract-testing/skills/pactflow ~/.config/opencode/skills/pactflow
+
+# Project-level
+mkdir -p .opencode/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow .opencode/skills/pactflow
+```
+
+### Codex
+
+```bash
+# Project-level
+mkdir -p .agents/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow .agents/skills/pactflow
+
+# Global
+mkdir -p ~/.agents/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow ~/.agents/skills/pactflow
+```
+
+### Kiro
+
+Use the Import from GitHub option: open **Agent Steering & Skills → + → Import a skill → GitHub** and paste:
+
+```
+https://github.com/pactflow/pactflow-agent-skills/tree/main/plugins/swagger-contract-testing/skills/pactflow
+```
+
+Or manually:
+
+```bash
+mkdir -p .kiro/skills
+cp -r plugins/swagger-contract-testing/skills/pactflow .kiro/skills/pactflow
+```
+
+---
+
+## Using the Pact CLI (no MCP required)
+
+If you have the `pact-broker` CLI installed and broker credentials set in your environment, the skill can interact with your broker directly via the Bash tool — no MCP server needed. This works with both PactFlow Cloud and open-source Pact Broker.
+
+### Install the CLI
+
+See the [Pact CLI installation guide](/implementation_guides/cli/pact-broker-cli) for install options, or ask the skill to install it for you:
+
+```
+Install the pact-broker CLI
+```
+
+### Set credentials
+
+```bash
+# PactFlow Cloud
+export PACT_BROKER_BASE_URL="https://yourorg.pactflow.io"
+export PACT_BROKER_TOKEN="your-api-token"
+
+# Open-source Pact Broker
+export PACT_BROKER_BASE_URL="https://your-broker.example.com"
+export PACT_BROKER_USERNAME="admin"
+export PACT_BROKER_PASSWORD="password"
+```
+
+With these set, the skill can run commands like:
+
+```bash
+pact-broker can-i-deploy --pacticipant FrontendApp --version abc123 --to-environment production
+pact-broker record-deployment --pacticipant FrontendApp --version abc123 --environment production
+pact-broker publish ./pacts --consumer-app-version $GIT_COMMIT --branch $GIT_BRANCH
+pact-broker list-environments
+pact-broker create-or-update-pacticipant --name PaymentService --main-branch main
+```
+
+For BDCT (PactFlow Cloud only), the `pactflow` CLI extension handles provider contract publishing:
+
+```bash
+pactflow publish-provider-contract openapi.yaml \
+  --provider MyProvider \
+  --provider-app-version $GIT_COMMIT \
+  --branch $GIT_BRANCH \
+  --specification oas \
+  --verification-success
+```
+
+### What the CLI cannot do
+
+The CLI does not expose the contract matrix, AI generation and review tools, BDCT cross-contract verification results, or label management. For those capabilities, configure the [SmartBear MCP server](#adding-a-live-broker-connection).
+
+---
+
+## Adding a live broker connection
+
+For any tool other than Claude Code (which handles this automatically via the plugin), configure the SmartBear MCP server to connect the skill to your actual broker.
+
+You can ask the skill to walk you through the setup or configure it for you:
+
+```
+Set up the SmartBear MCP server for Claude Desktop
+```
+
+### Prerequisites
+
+- Node.js 20+
+- A PactFlow account or self-hosted Pact Broker
+
+### Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "smartbear": {
+      "command": "npx",
+      "args": ["-y", "@smartbear/mcp@latest"],
+      "env": {
+        "PACT_BROKER_BASE_URL": "https://yourorg.pactflow.io",
+        "PACT_BROKER_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+### VS Code
+
+Create or edit `.vscode/mcp.json` in your project root:
+
+```json
+{
+  "servers": {
+    "smartbear": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@smartbear/mcp@latest"],
+      "env": {
+        "PACT_BROKER_BASE_URL": "https://yourorg.pactflow.io",
+        "PACT_BROKER_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+### Cursor
+
+Edit `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "smartbear": {
+      "command": "npx",
+      "args": ["-y", "@smartbear/mcp@latest"],
+      "env": {
+        "PACT_BROKER_BASE_URL": "https://yourorg.pactflow.io",
+        "PACT_BROKER_TOKEN": "your-api-token"
+      }
+    }
+  }
+}
+```
+
+### Open-source Pact Broker
+
+Replace `PACT_BROKER_TOKEN` with `PACT_BROKER_USERNAME` and `PACT_BROKER_PASSWORD` in any of the configs above:
+
+```json
+{
+  "env": {
+    "PACT_BROKER_BASE_URL": "https://your-self-hosted-broker.example.com",
+    "PACT_BROKER_USERNAME": "admin",
+    "PACT_BROKER_PASSWORD": "your-password"
+  }
+}
+```
+
+:::note
+AI test generation, AI test review, and team metrics require PactFlow Cloud. These tools are not available when connected to an open-source Pact Broker.
+:::
+
+### Verify the connection
+
+Once configured, ask your assistant:
+
+```
+List the environments in my PactFlow workspace
+```
+
+If the connection is working, it will call `contract-testing_list_environments` and return results from your workspace.
+
+---
+
+## What you can do
+
+### Writing consumer tests
+
+The skill knows the Pact DSL for every supported language and can generate a complete, runnable consumer test from a description of the interaction. Supported languages: JavaScript, TypeScript, Java, Kotlin, Go, .NET (C#), Ruby, PHP, Swift.
+
+It applies matching rules correctly by default — `like()` for type matching, `eachLike()` for arrays, `term()` for regex — and knows when exact value matching is appropriate. It will also flag common mistakes like over-specifying response bodies or using exact matching for timestamps and IDs.
+
+**With a live broker connection (PactFlow Cloud):** the `contract-testing_generate_pact_tests` tool generates tests directly from request/response pairs, existing client code, or an OpenAPI spec. Before generating, it calls `contract-testing_get_provider_states` to fetch the provider states already defined in your workspace, so new interactions reuse state names that the provider already knows how to set up.
+
+```
+Generate a consumer test for GET /orders/{id} returning a 200 with order details.
+Check what provider states already exist for OrderService first.
+```
+
+```
+Generate a Pact test in Go from this OpenAPI spec, only for the POST /payments endpoint.
+```
+
+### Message pacts (Kafka, SQS, SNS)
+
+The skill understands the hexagonal architecture pattern for message contract testing: the Pact test calls your domain function (the port) directly, bypassing the Kafka/SQS adapter entirely. It will help you split the code into the right layers before writing tests, so you don't end up testing infrastructure.
+
+It covers both async (fire-and-forget) and sync (request/reply streaming) message patterns, with examples in JavaScript and Java.
+
+```
+Help me write a Pact message test for the OrderCreated event consumed from Kafka in Java.
+```
+
+### Provider verification
+
+The skill knows the exact `consumerVersionSelectors` configuration needed to avoid the most common can-i-deploy failure — a provider that never verifies the version currently deployed in production:
+
+```javascript
+consumerVersionSelectors: [
+  { mainBranch: true },
+  { matchingBranch: true },
+  { deployedOrReleased: true },  // the one most teams are missing
+],
+enablePending: true,
+publishVerificationResults: process.env.CI === "true",
+providerVersion: process.env.GIT_COMMIT,
+providerVersionBranch: process.env.GIT_BRANCH,
+```
+
+It can write provider state handlers, explain how to handle authentication in verification (basic auth, bearer tokens, JWKS), and walk through fixing specific verification failures.
+
+```
+Set up provider verification in my Spring Boot app. We use OAuth2 with a test identity provider.
+```
+
+```
+My provider verification is failing with 'unexpected body'. Walk me through fixing it.
+```
+
+### CI/CD pipeline setup
+
+The skill covers the full [Pact Nirvana](/pact_nirvana) journey — Bronze through Diamond — and can scaffold the exact CI steps for your platform (GitHub Actions, GitLab CI, CircleCI, Jenkins).
+
+It will configure:
+
+- Consumer CI: run tests → publish pact → can-i-deploy gate → deploy → record deployment
+- Provider CI: fetch pacts → verify → publish results → can-i-deploy gate → deploy → record deployment
+- Webhooks to trigger provider verification immediately when a pact changes
+
+```
+Write GitHub Actions workflows for both consumer and provider CI pipelines.
+```
+
+### can-i-deploy diagnostics
+
+**Skill only:** the assistant walks through the most common root causes systematically — missing `deployedOrReleased` selector, verification results not published, no webhook firing on pact changes — and explains which CI config to fix.
+
+**With a live broker connection:** the assistant inspects your actual workspace. It calls `contract-testing_can_i_deploy` to get the result, then uses `contract-testing_matrix` to identify exactly which consumer-provider version pair is unverified or failing, and `contract-testing_get_currently_deployed_versions` to confirm what is actually in production. It traces the failure to a specific root cause rather than guessing.
+
+```
+Why is can-i-deploy failing for FrontendApp version abc123 in production?
+```
+
+### Publishing contracts and verification results
+
+**With a live broker connection:** the assistant can call `contract-testing_publish_consumer_contracts` to upload pact files directly, or `contract-testing_get_pacts_for_verification` to fetch the pacts a provider should verify in its current CI run.
+
+```
+Publish this pact file for FrontendApp version abc123 on the main branch.
+```
+
+### Deployment and release tracking
+
+**With a live broker connection:** after a successful deploy, the assistant calls `contract-testing_record_deployment` to update the contract matrix. For mobile apps and shared libraries where multiple versions coexist, it uses `contract-testing_record_release` instead — which keeps all released versions marked as supported simultaneously.
+
+It can also tell you what is currently deployed in any environment:
+
+```
+What version of PaymentService is deployed in staging right now?
+```
+
+```
+Record the deployment of OrderService version abc123 to production.
+```
+
+### Workspace management
+
+**With a live broker connection:** the assistant can manage the full lifecycle of services in your workspace.
+
+**Pacticipants** — register new services, set main branches so branch-based can-i-deploy works correctly, update repository URLs, apply and remove labels:
+
+```
+Register a new service called NotificationService with main branch 'main'.
+```
+
+**Environments** — list environments and their UUIDs, create new ones, mark them as production:
+
+```
+Create a staging environment and a production environment.
+```
+
+**Webhooks** — create webhooks to trigger provider CI when a pact changes, test them manually, manage secrets used in webhook authentication:
+
+```
+Create a webhook to trigger the UserService verification pipeline when a new pact is published.
+```
+
+**Cleanup** — remove stale feature branches, delete decommissioned services:
+
+```
+Delete the feature/old-checkout branch for FrontendApp.
+```
+
+### Network and blast radius analysis
+
+**With a live broker connection:** `contract-testing_get_pacticipant_network` returns the full integration graph for a service — all consumers that depend on it, and all providers it depends on. Use this before making breaking changes to understand the blast radius.
+
+```
+Which services depend on UserService?
+```
+
+### Metrics and observability
+
+**With a live broker connection:** `contract-testing_get_metrics` returns workspace-wide usage statistics. On PactFlow Cloud, `contract-testing_get_team_metrics` breaks this down per team.
+
+### AI-assisted test review (PactFlow Cloud only)
+
+The `contract-testing_review_pact_tests` tool reads your existing test files and returns a ranked list of best-practice violations and improvement recommendations. You can also pass in error output from a failing test run to get targeted diagnosis.
+
+```
+Review my existing Pact tests in ./src/__tests__/consumer.test.ts for best-practice violations.
+```
+
+```
+My provider verification is failing with this error output. What's wrong?
+[paste error]
+```
+
+### Bi-Directional Contract Testing (PactFlow Cloud only)
+
+For BDCT workflows, the skill can help you publish a provider contract (OpenAPI spec + self-verification results from Dredd, Schemathesis, or similar), then use the BDCT tools to inspect cross-contract verification results and diagnose compatibility failures — without the provider needing to run the consumer pact suite directly.
+
+```
+Publish our OpenAPI spec as a provider contract for UserService version abc123.
+The Dredd self-verification passed.
+```
+
+```
+Show the cross-contract verification results for UserService version abc123.
+```
+
+### Example prompts
+
+```
+Help me write a consumer test for the GET /orders endpoint in TypeScript using pact-js v13
+```
+
+```
+Why is can-i-deploy failing for OrderService in production?
+```
+
+```
+Generate a Pact test for PaymentService — fetch the existing provider states first
+```
+
+```
+Review my Pact tests in src/__tests__/ for best-practice violations
+```
+
+```
+Set up provider verification in Spring Boot with OAuth2 auth and the right consumer version selectors
+```
+
+```
+Write GitHub Actions CI workflows for both consumer and provider pipelines
+```
+
+```
+Which services depend on UserService? I'm making a breaking change.
+```
+
+```
+Record the deployment of FrontendApp version abc123 to production
+```
+
+---
+
+## Subagents
+
+The plugin ships with three specialist subagents that the PactFlow skill can delegate to automatically. Each runs as an independent agent with its own set of tools, so it can read your codebase, write files, and call MCP tools without interrupting the main conversation.
+
+You don't invoke them by name — the skill detects when a task is better handled by a subagent and dispatches it. You can also trigger them explicitly with a natural language prompt.
+
+### pact-generator
+
+**Purpose:** generates complete, runnable Pact consumer tests and matching provider state handlers.
+
+When asked to write tests, the pact-generator agent follows a specific sequence before writing a single line of code:
+
+1. Reads any OpenAPI specs, existing API client code, or test files you point it to
+2. Calls `contract-testing_get_provider_states` to fetch existing provider state names from your broker — new interactions reuse these rather than inventing duplicates
+3. Calls `contract-testing_list_pacticipants` to confirm the exact consumer and provider names as registered in your workspace
+4. Uses `contract-testing_generate_pact_tests` (PactFlow Cloud) to generate the test with AI, or falls back to generating it directly if that tool is unavailable
+
+The output is always a complete, runnable file — not a snippet. It includes:
+
+- The full consumer test with imports, mock setup, interaction definitions, and assertions
+- Matching provider state handler code for every state referenced in the test
+- A short note explaining which states were reused from the broker vs newly created, and the matching strategy applied
+
+It applies matching rules correctly by default: `like()` for type matching, `eachLike()` for arrays, `term()` for regex patterns. It will not generate tests that over-specify response bodies or use exact matchers where type matchers are appropriate.
+
+**Triggers:**
+
+```
+Write a Pact test for the GET /orders/{id} endpoint in TypeScript
+Generate contract tests for the PaymentService integration
+Convert this API client code into a Pact test
+Create provider state handlers for the existing pacts
+```
+
+### pact-reviewer
+
+**Purpose:** audits existing Pact tests and provider verification code for best-practice violations and returns a ranked list of findings.
+
+The pact-reviewer agent reads your test files, checks them against the broker state, and produces a structured review:
+
+1. Reads test files using Glob/Grep to locate all relevant files
+2. Calls `contract-testing_get_provider_states` to check for duplicated or mismatched state names between your tests and the broker
+3. Uses `contract-testing_review_pact_tests` (PactFlow Cloud) for AI-powered analysis, passing in your files and any error output
+4. Applies a standard set of best-practice rules (see below) on top of the AI output
+
+Findings are returned in severity order: **Critical → High → Medium → Low**, each with a file path, line number, explanation of the problem, and what to do instead.
+
+**Consumer test red flags it looks for:**
+
+- Exact matchers where type matchers would suffice
+- Testing provider business logic rather than the consumer's API client
+- Missing provider states for data-dependent interactions
+- Random or dynamic data in pact definitions (breaks content hashing and reproducibility)
+- State names that nearly duplicate existing ones in the broker
+
+**Provider verification red flags:**
+
+- `publishVerificationResults: true` outside of CI (pollutes the matrix)
+- Missing `providerVersion` or `providerVersionBranch` (results don't associate correctly)
+- `consumerVersionSelectors` missing `{ deployedOrReleased: true }` (the most common regression risk)
+- No `enablePending: true` (breaks the provider build when a new consumer interaction is added)
+- State handlers that set up more data than needed, or are missing teardown
+
+**Triggers:**
+
+```
+Review my Pact tests in src/__tests__/ for best-practice violations
+Audit the provider verification config in our Spring Boot app
+My provider verification is failing — review the test files and this error output: [paste output]
+```
+
+### pact-implementor
+
+**Purpose:** builds a new Pact client library from scratch for a language that doesn't have one yet.
+
+This agent runs on Opus and is designed for the substantial task of wrapping the Pact FFI or implementing the Pact specification in a new language. It knows the full internal architecture of Pact libraries — consumer side, provider side, matching rules, Integration JSON, and the FFI surface — and recommends the correct approach:
+
+1. **Wrap the Rust FFI** (strongly recommended) — the `pact_ffi` crate exposes the entire Pact Rust core as a C ABI-compatible shared library. This is how Go, .NET, PHP, C++, and Python V3 are built. It gives you immediate V1–V4 spec support with no additional work.
+2. **Use the mock server HTTP API** — simpler, no FFI required, suitable for languages with no C interop.
+3. **Implement from the spec** — only for languages that genuinely cannot use FFI or HTTP (e.g. embedded systems).
+
+It scaffolds the correct FFI binding pattern for the target language, generates the full mock server lifecycle code, and explains Integration JSON (the inline matcher format used for V3+ matching rules). It also knows which reference implementations to study for guidance (Go, .NET, PHP).
+
+**Triggers:**
+
+```
+I want to build a Pact library for Zig
+Help me wrap the Pact FFI in Elixir
+Build a Pact client library for Lua using LuaJIT FFI
+Port the Pact mock server to a new runtime
+```
+
+### pact-maintainer
+
+**Purpose:** audits workspace health, diagnoses can-i-deploy failures, cleans up stale state, and handles ongoing maintenance tasks across the full PactFlow workspace.
+
+This is the broadest of the subagents — it has access to almost every `contract-testing_*` tool and handles the operational side of a contract testing ecosystem: keeping the broker clean, verifications green, and environments accurate. It can be pointed at one specific problem or asked for a full workspace audit.
+
+**Task 1 — Health audit**
+
+When asked to audit the workspace, it works through a structured checklist:
+
+1. Lists all pacticipants and integrations to map the full consumer-provider graph
+2. Queries the matrix for each integration to find failing or unknown verifications
+3. Lists branches per pacticipant and flags any not updated in over 30 days
+4. Checks every environment for services with no recorded deployments
+5. Lists webhooks and flags any that are disabled or have no recent executions
+6. Pulls workspace metrics for headline numbers
+
+The output is a structured health report: summary counts, a list of failing/unknown verifications, stale branches, and a ranked recommendations list.
+
+**Task 2 — can-i-deploy diagnosis and fix**
+
+Runs `contract-testing_can_i_deploy`, then drills into the matrix to identify the exact failing row, classifies the root cause (never verified, verification failed, no results published, pending pact), reads the relevant test files, applies a fix using AI review if needed, and reports the specific cause and action taken.
+
+**Task 3 — Update pacts after an API change**
+
+Given a breaking or additive API change, it fetches all consumer pacts currently being verified, reads the affected test files, classifies each change as additive (no action needed) or breaking (consumer tests must be updated), applies the updates, republishes, and checks the matrix to confirm the fix.
+
+**Task 4 — Stale state cleanup**
+
+Deletes merged feature branches, removes decommissioned services (after checking for active deployments and network dependents), and cleans up orphaned integrations. It will never delete a pacticipant with currently deployed versions without explicit confirmation.
+
+**Task 5 — Environment and webhook setup**
+
+Creates environments with the correct `production` flag, configures standard webhooks to trigger provider CI on pact changes (using PactFlow's template variables like `${pactbroker.pactUrl}`), and tests webhooks by executing them manually.
+
+**Task 6 — Deployment recording**
+
+Records deployments and releases after CI steps using the correct tool for the workflow: `record_deployment` for traditional services (one version active per environment), `record_release` for mobile apps and libraries (multiple versions simultaneously supported).
+
+**Triggers:**
+
+```
+Give me a health report for our PactFlow workspace
+Why is can-i-deploy failing for CheckoutService?
+Clean up stale branches across all our services
+Update our pacts — we renamed the /users endpoint to /accounts
+Set up environments and a webhook to trigger provider verification
+```
+
+### bdct-tester
+
+**Purpose:** drives a full Bi-Directional Contract Testing flow end-to-end — consumer tests, provider OpenAPI contract, publication, cross-contract verification — and loops until BDCT passes or a maximum of 5 iterations is reached.
+
+This agent handles everything from generating consumer tests to publishing both sides of the contract and diagnosing failures from PactFlow's cross-contract verification results. It is designed to take you from zero to a green BDCT result in a single invocation.
+
+**Phase 1 — Discovery**
+
+Locates the provider and consumer codebases (asking the user for paths if needed), finds the provider's existing OpenAPI spec, reads the consumer's API client code to understand which endpoints and fields it uses, and resolves the pacticipant names from existing Pact config or by asking.
+
+It will stop immediately if no OpenAPI spec exists on the provider side — BDCT requires one, and it will not create it on behalf of the provider team.
+
+**Phase 2 — Consumer test generation**
+
+Generates Pact V4 consumer tests with high coverage targets:
+
+- Every endpoint the consumer calls (happy path)
+- Every distinct response shape (e.g. empty array vs populated array)
+- Common error cases the consumer handles (404, 400, 401, 422)
+- Each optional field as both present and absent (separate interactions with different provider states)
+
+It then runs the tests to generate the pact file, fixing any failures before moving on.
+
+**Phase 3 — Publication**
+
+Publishes both contracts to PactFlow:
+
+- Consumer pact via `contract-testing_publish_consumer_contracts`
+- Provider OpenAPI spec + self-verification results via `contract-testing_publish_provider_contract`
+
+**Phase 4 — Verify and loop**
+
+Polls the contract matrix until results arrive, then checks `contract-testing_get_bdct_cross_contract_verification_results` for detailed failure reasons.
+
+When BDCT fails, it classifies the failure and applies the correct fix — for example, if the spec is missing a field the provider actually returns, it updates the spec to document it; if the consumer is using a field the provider never returns, it removes that field from the consumer test. It then bumps the version and republishes.
+
+This loop runs up to 5 times. If BDCT still fails after 5 iterations, it stops and reports the remaining failures with a diagnosis.
+
+**Output**
+
+At the end it reports the final status, the consumer and provider contract versions and publication URLs, the cross-contract verification result, and any remaining failures.
+
+**Triggers:**
+
+```
+Set up bi-directional contract testing for the OrderService integration
+Make BDCT pass for FrontendApp and ProductsService
+Publish and verify contracts for our checkout flow
+```
+
+---
+
+## SmartBear MCP tools
+
+The full `contract-testing_*` tool catalog — AI generation, can-i-deploy, the contract matrix, BDCT, environments, webhooks, secrets, and more — is documented on the [SmartBear MCP](./smartbear-mcp.md) page.
+
+---
+
+## Troubleshooting
+
+| Symptom                             | Likely cause                    | Fix                                                                   |
+| ----------------------------------- | ------------------------------- | --------------------------------------------------------------------- |
+| `401 Unauthorized` from MCP tools   | Wrong or missing token          | Check `PACT_BROKER_TOKEN` matches the value from your API tokens page |
+| `404 Not Found` from MCP tools      | Wrong broker URL                | Verify `PACT_BROKER_BASE_URL` — no trailing slash, correct subdomain  |
+| MCP tools not appearing             | MCP server not starting         | Run `npx @smartbear/mcp@latest` in a terminal to see startup errors   |
+| AI generation/review returns `401`  | Missing PactFlow AI entitlement | Ask the assistant to check your entitlements                          |
+| Skill not activating in Claude Code | Plugin not reloaded             | Run `/reload-plugins` inside a Claude Code session                    |

--- a/website/docs/ai_tools/smartbear-mcp.md
+++ b/website/docs/ai_tools/smartbear-mcp.md
@@ -1,0 +1,652 @@
+---
+title: SmartBear MCP Server
+sidebar_label: SmartBear MCP
+---
+
+# SmartBear MCP Server
+
+The `@smartbear/mcp` package is a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes your PactFlow or Pact Broker workspace as a set of `contract-testing_*` tools. When configured alongside the [PactFlow skill](./pactflow-skill.md), your AI assistant gains structured, programmatic access to your workspace — direct matrix queries, AI-assisted test generation and review using your live provider states, BDCT cross-contract verification results, and full management of every broker resource.
+
+For the official SmartBear documentation on the MCP server, see the [SmartBear MCP contract testing docs](https://developer.smartbear.com/smartbear-mcp/docs/contract-testing-with-pactflow).
+
+Without the MCP server, the skill can still interact with your broker via the `pact-broker` CLI if it is installed and credentials are set in the environment. The CLI covers the core operations — publishing pacts, can-i-deploy, recording deployments, managing environments and webhooks — but does not expose the contract matrix, AI generation tools, or BDCT results. See the [comparison table](./pactflow-skill.md#skill-vs-pact-cli-vs-full-plugin) for the full breakdown.
+
+## Installation and configuration
+
+If the PactFlow skill is already active, you can ask it to install and configure the MCP server for you:
+
+```
+Set up the SmartBear MCP server
+```
+
+For manual setup, see the [PactFlow Skill](./pactflow-skill.md#adding-a-live-broker-connection) page for full instructions per tool (Claude Code, Claude Desktop, VS Code, Cursor). The short version:
+
+```bash
+# Claude Code — plugin install handles this automatically
+/plugin install swagger-contract-testing@pactflow-agent-skills
+
+# All other tools — run the MCP server via npx
+npx @smartbear/mcp@latest
+```
+
+**Required environment variables:**
+
+| Variable               | Required for       | Description                                                 |
+| ---------------------- | ------------------ | ----------------------------------------------------------- |
+| `PACT_BROKER_BASE_URL` | All                | Full URL to your broker, e.g. `https://yourorg.pactflow.io` |
+| `PACT_BROKER_TOKEN`    | PactFlow Cloud     | API token from `Settings → API Tokens`                      |
+| `PACT_BROKER_USERNAME` | Open-source broker | HTTP Basic Auth username                                    |
+| `PACT_BROKER_PASSWORD` | Open-source broker | HTTP Basic Auth password                                    |
+
+Use a token **or** username/password — not both.
+
+:::note Cloud-only tools
+Tools marked **☁ Cloud only** require a PactFlow Cloud account. They will not work when connected to an open-source Pact Broker.
+:::
+
+---
+
+## AI tools ☁ Cloud only
+
+### `contract-testing_generate_pact_tests`
+
+Generates a complete, runnable Pact test using PactFlow AI. Accepts any combination of inputs and returns idiomatic test code in the target language with correct matching rules applied.
+
+**Inputs:**
+
+| Parameter                   | Description                                                                                                                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `language`                  | Target language (`javascript`, `typescript`, `java`, `kotlin`, `go`, `dotnet`, `ruby`, `python`, `php`, `swift`). Inferred if omitted and code files are provided. |
+| `request_response.request`  | Raw HTTP request string or description                                                                                                                             |
+| `request_response.response` | Raw HTTP response string or description                                                                                                                            |
+| `code`                      | Array of code files (API client, models, utilities) to generate from                                                                                               |
+| `openapi.document`          | OpenAPI spec content (inline)                                                                                                                                      |
+| `openapi.matcher`           | Filter to a specific endpoint, method, or status code within a spec (e.g. `GET /orders 200`)                                                                       |
+| `openapi.remoteDocument`    | URL to a remote OpenAPI spec, with optional `auth` credentials                                                                                                     |
+| `additional_instructions`   | Extra constraints — framework version, test runner, naming conventions                                                                                             |
+| `test_template`             | An existing test file to use as a structural template, so output matches your team's conventions                                                                   |
+
+The [pact-generator subagent](./pactflow-skill.md#pact-generator) always calls `contract-testing_get_provider_states` before invoking this tool, ensuring generated tests reuse existing provider state names from your workspace rather than creating duplicates.
+
+**Example:**
+
+```
+Generate a consumer test for the POST /orders endpoint.
+Use TypeScript with pact-js v13 and Vitest.
+Check what provider states already exist for OrderService first.
+```
+
+---
+
+### `contract-testing_review_pact_tests`
+
+Reviews existing Pact tests against best practices and returns a prioritised list of findings.
+
+**Inputs:**
+
+| Parameter                                           | Description                                                                                                |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `pact_tests`                                        | Test files to review — required                                                                            |
+| `code`                                              | Supporting files for context (API client, models)                                                          |
+| `openapi.document` / `.matcher` / `.remoteDocument` | API spec for additional context                                                                            |
+| `user_instructions`                                 | Areas to focus on, e.g. "check matching rules" or "focus on provider state naming"                         |
+| `error_messages`                                    | Output from a failing test run or broken provider verification — the review will target the actual failure |
+
+The [pact-reviewer subagent](./pactflow-skill.md#pact-reviewer) uses this tool as the core of its review process, passing your files and any error output directly to it.
+
+**Example:**
+
+```
+Review the Pact tests in src/__tests__/consumer.test.ts.
+My provider verification is failing with this error:
+[paste error output]
+```
+
+---
+
+### `contract-testing_check_pactflow_ai_entitlements`
+
+Diagnoses 401 errors or missing-credit issues when the AI generation or review tools fail. Takes no parameters. Returns a plain-language explanation of your account's current AI entitlement state — whether you have credits remaining, whether the feature is enabled on your plan, and what to do if it isn't.
+
+Both pact-generator and pact-reviewer call this automatically when they receive a 401, before falling back to non-AI generation.
+
+---
+
+## Deployment safety
+
+### `contract-testing_can_i_deploy`
+
+The deployment safety gate. Checks the contract matrix to determine whether a specific version of a service is safe to deploy to a given environment. Run this in CI **before** deploying.
+
+**Parameters:** `pacticipant` (required), `version` (required), `environment` (required — use the environment name, e.g. `production`)
+
+Returns a success or failure result with a human-readable explanation. When it fails, use `contract-testing_matrix` to diagnose the root cause.
+
+**Example:**
+
+```
+Is FrontendApp version abc123 safe to deploy to production?
+```
+
+---
+
+### `contract-testing_matrix`
+
+Queries the contract verification matrix — the source of truth for what has and hasn't been verified. Use this to diagnose can-i-deploy failures, investigate a specific consumer-provider pair, or get an overview of verification state.
+
+**Key parameters:**
+
+| Parameter  | Description                                                                                                                                                             |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `q`        | Array of 1–2 pacticipant selectors. Each selector has `pacticipant` and one of: `version`, `branch`, `environment`, `latest`, `tag`, `mainBranch`, `deployedOrReleased` |
+| `latestby` | `cvp` — latest result per consumer version + provider; `cvpv` — latest per consumer version + provider version                                                          |
+| `limit`    | Max rows to return (1–1000, default 100)                                                                                                                                |
+
+**Reading the results:**
+
+| Matrix row state             | Meaning                                                  |
+| ---------------------------- | -------------------------------------------------------- |
+| No row exists                | Provider has never verified this consumer version        |
+| Row exists, `success: null`  | Verification is in progress or results weren't published |
+| Row exists, `success: false` | Provider verified and it failed — genuine contract break |
+| Row exists, `success: true`  | Verified and passing                                     |
+
+**Diagnosing a can-i-deploy failure:**
+
+```
+# Step 1: check what's actually deployed in production
+contract-testing_get_currently_deployed_versions  →  environmentId: <prod-uuid>
+
+# Step 2: query the matrix for this consumer version vs what's in production
+contract-testing_matrix
+  q: [
+    { pacticipant: "FrontendApp", version: "abc123" },
+    { pacticipant: "OrderService", deployed: true, environment: "production" }
+  ]
+  latestby: "cvp"
+```
+
+| Root cause                     | Fix                                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------------------- |
+| No matrix row (never verified) | Provider is missing `{ deployedOrReleased: true }` in `consumerVersionSelectors`    |
+| `success: false`               | Genuine contract break — fix the failing interaction                                |
+| Results not published          | Provider CI missing `publishVerificationResults: true` and `providerVersion` config |
+| No webhook firing              | Create a webhook for `contract_requiring_verification_published`                    |
+
+---
+
+## Contracts
+
+### `contract-testing_publish_consumer_contracts`
+
+Publishes consumer pact files to the broker. Run in consumer CI after tests pass.
+
+**Key parameters:**
+
+| Parameter                  | Description                                                                                                                                    |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pacticipantName`          | Consumer name as registered in the broker                                                                                                      |
+| `pacticipantVersionNumber` | Version number — use the git SHA                                                                                                               |
+| `branch`                   | Consumer branch name — use `$GIT_BRANCH`                                                                                                       |
+| `contracts`                | Array of pact objects: `{ consumerName, providerName, content (base64-encoded JSON), contentType: "application/json", specification: "pact" }` |
+| `buildUrl`                 | CI build URL for traceability                                                                                                                  |
+
+:::tip Always publish with branch
+Publishing without `branch` means the broker can't use `{ mainBranch: true }` or `{ matchingBranch: true }` selectors for this version.
+:::
+
+---
+
+### `contract-testing_get_pacts_for_verification`
+
+Fetches the pacts a provider should verify in its current CI run. Called by the provider pipeline, not manually.
+
+**Key parameters:**
+
+| Parameter                  | Description                                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| `providerName`             | Provider name                                                                         |
+| `providerVersionBranch`    | Current provider branch — used to resolve `matchingBranch` selectors                  |
+| `consumerVersionSelectors` | Array of selectors controlling which consumer versions are verified                   |
+| `includePendingStatus`     | `true` — new consumer interactions won't fail the provider build until first verified |
+| `includeWipPactsSince`     | ISO 8601 date — include new consumer pacts automatically for early feedback           |
+
+**Recommended selectors:**
+
+```json
+[
+  { "mainBranch": true },
+  { "matchingBranch": true },
+  { "deployedOrReleased": true }
+]
+```
+
+Missing `{ "deployedOrReleased": true }` is the single most common cause of can-i-deploy failures — without it the provider never verifies the version currently in production.
+
+---
+
+### `contract-testing_get_provider_states`
+
+Lists all provider states defined for a provider across all published pacts. **Always call this before generating new consumer tests** — it lets you reuse existing state names and avoid duplication.
+
+**Parameter:** `provider` (required)
+
+---
+
+### `contract-testing_publish_provider_contract` ☁ Cloud only (BDCT)
+
+Publishes a provider OpenAPI spec and self-verification results to PactFlow. Used in the [BDCT flow](#bi-directional-contract-testing-cloud-only) instead of running consumer pact tests on the provider.
+
+**Key parameters:**
+
+| Parameter                                   | Description                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------- |
+| `providerName`                              | Provider name                                                                     |
+| `pacticipantVersionNumber`                  | Version number — use git SHA                                                      |
+| `branch`                                    | Provider branch                                                                   |
+| `contract.content`                          | Base64-encoded OpenAPI spec (YAML or JSON)                                        |
+| `contract.contentType`                      | `application/yaml` or `application/json`                                          |
+| `contract.specification`                    | Must be `oas`                                                                     |
+| `contract.selfVerificationResults.success`  | `true` or `false` — whether the provider's own verification tool passed           |
+| `contract.selfVerificationResults.verifier` | Tool used for self-verification: `dredd`, `schemathesis`, `postman`, `curl`, etc. |
+
+The `selfVerificationResults.success` boolean is critical. PactFlow will not mark the provider as verified unless this is `true`.
+
+---
+
+## Pacticipants
+
+Pacticipants are the services registered in your workspace. Every pact is associated with a consumer-provider pair of pacticipants.
+
+| Tool                                  | What it does                                                                                              |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `contract-testing_list_pacticipants`  | List all registered services. Optional: `pageNumber`, `pageSize`                                          |
+| `contract-testing_get_pacticipant`    | Get metadata for a service                                                                                |
+| `contract-testing_create_pacticipant` | Register a new service. Set `mainBranch` on creation so `{ mainBranch: true }` selectors work immediately |
+| `contract-testing_patch_pacticipant`  | Partially update a service (only provided fields change). Preferred for targeted changes                  |
+| `contract-testing_update_pacticipant` | Fully replace a service's metadata — clears fields not provided                                           |
+| `contract-testing_delete_pacticipant` | Delete a service and all its data. Irreversible. Check for active deployments first                       |
+
+**Registering a new service:**
+
+```
+contract-testing_create_pacticipant
+  name: "PaymentService"
+  displayName: "Payment Service"
+  mainBranch: "main"
+  repositoryUrl: "https://github.com/example/payment-service"
+```
+
+**Setting the main branch on an existing service:**
+
+```
+contract-testing_patch_pacticipant
+  pacticipantName: "PaymentService"
+  mainBranch: "main"
+```
+
+---
+
+## Branches and versions
+
+Branches are a first-class concept in the Pact Broker (from v2.82.0). They supersede tags for tracking which pacts belong to which development line.
+
+| Tool                                                 | What it does                                                           |
+| ---------------------------------------------------- | ---------------------------------------------------------------------- |
+| `contract-testing_list_branches`                     | List branches for a service. Optional: `q` (name filter)               |
+| `contract-testing_get_branch`                        | Get branch metadata                                                    |
+| `contract-testing_get_branch_versions`               | List versions published from a branch                                  |
+| `contract-testing_delete_branch`                     | Delete a branch and its version associations. Clean up after PRs merge |
+| `contract-testing_list_pacticipant_versions`         | List all versions for a service                                        |
+| `contract-testing_get_pacticipant_version`           | Get metadata for a specific version                                    |
+| `contract-testing_get_latest_pacticipant_version`    | Get the most recent version, optionally filtered by tag                |
+| `contract-testing_get_deployed_versions_for_version` | Check deployment records for a version in a specific environment       |
+| `contract-testing_get_released_versions_for_version` | Check release records for a version (mobile/library workflows)         |
+
+:::tip Branch cleanup
+Delete merged feature branches with `contract-testing_delete_branch` to keep the workspace clean. The associated versions are cleaned up automatically. Never delete a branch that has deployed versions without checking first.
+:::
+
+---
+
+## Environments and deployments
+
+Environments are named deployment targets (e.g. `staging`, `production`). The broker needs to know what is deployed where in order for can-i-deploy to work correctly.
+
+### Managing environments
+
+| Tool                                  | What it does                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------- |
+| `contract-testing_list_environments`  | List all environments and their UUIDs                                     |
+| `contract-testing_get_environment`    | Get details for a specific environment                                    |
+| `contract-testing_create_environment` | Create an environment. Set `production: true` for production environments |
+| `contract-testing_update_environment` | Replace environment config                                                |
+| `contract-testing_delete_environment` | Delete an environment and all its deployment/release records              |
+
+**Creating environments:**
+
+```
+contract-testing_create_environment  name: "staging"     production: false
+contract-testing_create_environment  name: "production"  production: true
+```
+
+Environment UUIDs are needed for recording deployments. Retrieve them with `contract-testing_list_environments`.
+
+### Recording deployments
+
+Use `contract-testing_record_deployment` for traditional services where one version is active per environment at a time. Recording a new deployment automatically marks the previous version as undeployed.
+
+```
+contract-testing_record_deployment
+  pacticipantName: "FrontendApp"
+  versionNumber: "abc1234"
+  environmentId: "<uuid-of-production>"
+  applicationInstance: "blue"   # optional — for blue/green deployments
+```
+
+### Recording releases
+
+Use `contract-testing_record_release` for mobile apps and shared libraries where multiple versions coexist simultaneously. Unlike `record_deployment`, this does not mark previous versions as inactive — all released versions remain "supported".
+
+```
+contract-testing_record_release
+  pacticipantName: "MobileApp"
+  versionNumber: "3.2.1"
+  environmentId: "<uuid-of-production>"
+```
+
+### Checking what is deployed
+
+```
+# What is currently deployed in production?
+contract-testing_get_currently_deployed_versions  →  environmentId: <prod-uuid>
+
+# What versions are currently supported (mobile/library)?
+contract-testing_get_currently_supported_versions  →  environmentId: <prod-uuid>
+```
+
+---
+
+## Bi-Directional Contract Testing ☁ Cloud only
+
+BDCT removes the need for the provider to run consumer Pact tests. Instead, the provider publishes its OpenAPI spec and the results of a self-verification tool (Dredd, Schemathesis, Postman). PactFlow performs the cross-contract comparison automatically.
+
+See [BDCT vs Standard Pact](#bdct-vs-standard-pact) for a comparison of the two approaches.
+
+### Investigating a BDCT failure
+
+Work from broad to specific:
+
+**1. Overall cross-contract result for a provider version**
+
+```
+contract-testing_get_bdct_cross_contract_verification_results
+  providerName: "OrderService"
+  providerVersionNumber: "def5678"
+```
+
+Shows the overall pass/fail and which consumer pact interactions failed the spec comparison.
+
+**2. Provider self-verification results**
+
+```
+contract-testing_get_bdct_provider_contract_verification_results
+  providerName: "OrderService"
+  providerVersionNumber: "def5678"
+```
+
+The output of the provider's own spec-verification tool. If `success: false`, the provider's implementation doesn't match its own spec — fix the implementation or the spec before BDCT can pass.
+
+**3. Consumer contracts used in the comparison**
+
+```
+contract-testing_get_bdct_consumer_contracts
+  providerName: "OrderService"
+  providerVersionNumber: "def5678"
+```
+
+Lists all consumer pact files PactFlow used in the cross-contract verification.
+
+**4. Pinpoint a specific consumer-provider version pair**
+
+When you know which consumer version is failing:
+
+```
+contract-testing_get_bdct_cross_contract_verification_results_by_consumer_version
+  providerName: "OrderService"
+  providerVersionNumber: "def5678"
+  consumerName: "CheckoutApp"
+  consumerVersionNumber: "abc1234"
+```
+
+Additional by-consumer-version tools available for: `get_bdct_consumer_contract_by_consumer_version`, `get_bdct_provider_contract_by_consumer_version`, `get_bdct_provider_contract_verification_results_by_consumer_version`, `get_bdct_consumer_contract_verification_results_by_consumer_version`.
+
+### Common BDCT failure patterns
+
+| Failure message                                 | Root cause                                            | Fix                                                                                         |
+| ----------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `$.body.X is not defined in the spec`           | Provider returns field X but spec doesn't document it | Update the spec to document it                                                              |
+| `$.body.X type mismatch`                        | Spec type doesn't match implementation                | Fix the spec to match what the provider actually returns                                    |
+| `Path /foo not found in spec`                   | Provider implements the path but spec is missing it   | Add the path to the spec                                                                    |
+| `Self-verification failed`                      | Provider's implementation doesn't match its own spec  | Fix the implementation or the spec                                                          |
+| BDCT fails even though self-verification passed | Spec is too strict for what the consumer expects      | Check for `additionalProperties: false`, missing response headers, or overly strict schemas |
+
+### BDCT vs Standard Pact
+
+|                              | Standard Pact                               | BDCT                                               |
+| ---------------------------- | ------------------------------------------- | -------------------------------------------------- |
+| Provider runs consumer tests | Yes                                         | No                                                 |
+| Provider publishes           | Verification results                        | OpenAPI spec + self-verification results           |
+| Cross-contract verification  | Done by provider test suite                 | Done by PactFlow automatically                     |
+| Consumer side                | Same                                        | Same                                               |
+| Availability                 | Cloud, On-Prem, Open Source                 | PactFlow Cloud only                                |
+| Best for                     | Tight teams with shared test infrastructure | Loosely coupled teams; existing spec-based testing |
+
+---
+
+## Integrations and network
+
+| Tool                                          | What it does                                                                                                   |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `contract-testing_list_integrations`          | List all consumer-provider pairings in the workspace                                                           |
+| `contract-testing_get_pacticipant_network`    | Get the full integration graph for a service — all consumers that depend on it and all providers it depends on |
+| `contract-testing_get_integrations_by_team` ☁ | List integrations owned by a specific team                                                                     |
+| `contract-testing_delete_integration`         | Delete a specific consumer-provider pairing and all associated data                                            |
+| `contract-testing_delete_all_integrations`    | Delete every integration in the workspace. Irreversible — use only when decommissioning an entire workspace    |
+
+`contract-testing_get_pacticipant_network` is the tool to reach for before making a breaking API change — it shows the blast radius across your entire ecosystem.
+
+```
+Which services depend on UserService?
+```
+
+---
+
+## Labels
+
+Labels are free-form tags you can apply to pacticipants for grouping and filtering.
+
+| Tool                                             | What it does                                  |
+| ------------------------------------------------ | --------------------------------------------- |
+| `contract-testing_list_labels`                   | List all labels used in the workspace         |
+| `contract-testing_get_pacticipant_label`         | Check whether a label is applied to a service |
+| `contract-testing_list_pacticipants_by_label`    | List all services with a given label          |
+| `contract-testing_add_label_to_pacticipant`      | Apply a label                                 |
+| `contract-testing_remove_label_from_pacticipant` | Remove a label                                |
+
+---
+
+## Metrics
+
+| Tool                                  | What it does                                                               |
+| ------------------------------------- | -------------------------------------------------------------------------- |
+| `contract-testing_get_metrics`        | Workspace-wide usage statistics — total pacticipants, pacts, verifications |
+| `contract-testing_get_team_metrics` ☁ | Per-team breakdown of the same metrics                                     |
+
+---
+
+## Webhooks
+
+Webhooks trigger actions (typically CI builds) when events occur in the broker. The most important use case is triggering provider verification immediately when a consumer publishes a changed pact, rather than waiting for the next scheduled provider CI run.
+
+### Webhook events
+
+| Event                                       | When triggered                                            | Typical use                                                          |
+| ------------------------------------------- | --------------------------------------------------------- | -------------------------------------------------------------------- |
+| `contract_published`                        | A pact is published for the first time or content changes | Trigger provider verification                                        |
+| `contract_requiring_verification_published` | A pact is published and needs verification                | **Recommended** — passes the pact URL directly to the provider build |
+| `verification_published`                    | A provider publishes a verification result                | Trigger consumer build to check can-i-deploy                         |
+| `provider_verification_succeeded`           | After a successful verification                           | Notify consumer team                                                 |
+| `provider_verification_failed`              | After a failed verification                               | Alert provider team                                                  |
+
+### Dynamic variables
+
+These can be used in webhook request bodies and URLs:
+
+```
+${pactbroker.consumerName}
+${pactbroker.providerName}
+${pactbroker.pactUrl}
+${pactbroker.verificationResultUrl}
+${pactbroker.consumerVersionNumber}
+${pactbroker.providerVersionNumber}
+${pactbroker.consumerVersionBranch}
+${pactbroker.providerVersionBranch}
+${pactbroker.githubVerificationStatus}
+```
+
+### Managing webhooks
+
+| Tool                                     | What it does                                                                        |
+| ---------------------------------------- | ----------------------------------------------------------------------------------- |
+| `contract-testing_list_webhooks`         | List all webhook configurations                                                     |
+| `contract-testing_get_webhook`           | Get details for a specific webhook                                                  |
+| `contract-testing_create_webhook`        | Create a webhook                                                                    |
+| `contract-testing_update_webhook`        | Update a webhook                                                                    |
+| `contract-testing_delete_webhook`        | Delete a webhook                                                                    |
+| `contract-testing_execute_webhook`       | Trigger a webhook manually using the last matching pact event as the test payload   |
+| `contract-testing_test_execute_webhooks` | Trigger a webhook with a specific consumer-provider pair as the payload for testing |
+
+**Example — trigger provider CI via GitHub Actions:**
+
+```
+contract-testing_create_webhook
+  description: "Trigger OrderService verification on pact change"
+  events: ["contract_requiring_verification_published"]
+  consumer: "FrontendApp"
+  provider: "OrderService"
+  request:
+    method: POST
+    url: "https://api.github.com/repos/example/order-service/actions/workflows/pact.yml/dispatches"
+    headers:
+      Authorization: "Bearer ${user.bearerToken}"
+      Content-Type: "application/json"
+    body:
+      ref: "main"
+      inputs:
+        pact_url: "${pactbroker.pactUrl}"
+```
+
+See the [webhook template library](/pact_broker/webhooks/template_library) for ready-made templates for GitHub Actions, CircleCI, GitLab CI, Jenkins, and Azure DevOps.
+
+---
+
+## Secrets
+
+Secrets store sensitive values (API keys, tokens) for use in webhook configurations. Storing them as secrets means the values aren't exposed in webhook config or logs.
+
+| Tool                             | What it does                                   |
+| -------------------------------- | ---------------------------------------------- |
+| `contract-testing_list_secrets`  | List all secrets (names and UUIDs, not values) |
+| `contract-testing_get_secret`    | Get secret metadata                            |
+| `contract-testing_create_secret` | Create a secret. `name` and `value` required   |
+| `contract-testing_update_secret` | Update a secret's value                        |
+| `contract-testing_delete_secret` | Delete a secret                                |
+
+Reference secrets in webhook headers using `${user.<secret-name>}`.
+
+---
+
+## Audit log ☁ Cloud only
+
+`contract-testing_get_audit_log` returns an audit trail of actions performed in the workspace — who did what and when. Useful for compliance and debugging unexpected state changes.
+
+---
+
+## Account and authentication
+
+| Tool                                      | What it does                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------------- |
+| `contract-testing_get_current_user`       | Get the identity of the currently authenticated user — name, email, roles |
+| `contract-testing_get_system_preferences` | Read system-level preferences for the workspace                           |
+| `contract-testing_get_user_preferences`   | Read preferences for the current user                                     |
+| `contract-testing_list_api_tokens`        | List API tokens for the current user                                      |
+| `contract-testing_regenerate_api_token`   | Regenerate an API token by UUID. The old token is immediately invalidated |
+
+---
+
+## Administration ☁ Cloud only
+
+Administration tools manage users, teams, roles, and system accounts in PactFlow Cloud. These are typically used by workspace administrators during onboarding or access control changes.
+
+### Users
+
+| Tool                                  | What it does                                |
+| ------------------------------------- | ------------------------------------------- |
+| `contract-testing_admin_list_users`   | List all users in the workspace             |
+| `contract-testing_admin_get_user`     | Get details for a specific user             |
+| `contract-testing_admin_create_user`  | Create a new user                           |
+| `contract-testing_admin_update_user`  | Update a user's details                     |
+| `contract-testing_admin_delete_user`  | Remove a user from the workspace            |
+| `contract-testing_admin_invite_users` | Send invitation emails to one or more users |
+
+### Teams
+
+| Tool                                           | What it does                               |
+| ---------------------------------------------- | ------------------------------------------ |
+| `contract-testing_admin_list_teams`            | List all teams                             |
+| `contract-testing_admin_get_team`              | Get details for a specific team            |
+| `contract-testing_admin_create_team`           | Create a team                              |
+| `contract-testing_admin_update_team`           | Update a team's name or settings           |
+| `contract-testing_admin_delete_team`           | Delete a team                              |
+| `contract-testing_admin_list_team_users`       | List users in a team                       |
+| `contract-testing_admin_get_team_user`         | Check whether a specific user is in a team |
+| `contract-testing_admin_set_team_users`        | Replace the full user list for a team      |
+| `contract-testing_admin_patch_team_users`      | Add or remove specific users from a team   |
+| `contract-testing_admin_remove_user_from_team` | Remove a single user from a team           |
+
+### Roles and permissions
+
+| Tool                                           | What it does                            |
+| ---------------------------------------------- | --------------------------------------- |
+| `contract-testing_admin_list_roles`            | List all roles defined in the workspace |
+| `contract-testing_admin_get_role`              | Get details for a specific role         |
+| `contract-testing_admin_create_role`           | Create a custom role                    |
+| `contract-testing_admin_update_role`           | Update a role's permissions             |
+| `contract-testing_admin_delete_role`           | Delete a custom role                    |
+| `contract-testing_admin_reset_roles`           | Reset all roles to the system defaults  |
+| `contract-testing_admin_list_permissions`      | List all available permissions          |
+| `contract-testing_admin_add_role_to_user`      | Assign a role to a user                 |
+| `contract-testing_admin_remove_role_from_user` | Remove a role from a user               |
+| `contract-testing_admin_set_user_roles`        | Replace a user's full role assignment   |
+
+### System accounts
+
+| Tool                                               | What it does                                              |
+| -------------------------------------------------- | --------------------------------------------------------- |
+| `contract-testing_admin_create_system_account`     | Create a system account (non-human user for CI pipelines) |
+| `contract-testing_admin_get_system_account_tokens` | Get the API tokens for a system account                   |
+
+---
+
+## Troubleshooting
+
+| Symptom                            | Likely cause                                      | Fix                                                                            |
+| ---------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `401 Unauthorized`                 | Wrong or missing token                            | Check `PACT_BROKER_TOKEN` matches the value from the API tokens page           |
+| `404 Not Found`                    | Wrong broker URL                                  | Verify `PACT_BROKER_BASE_URL` — no trailing slash, correct subdomain           |
+| Tools not appearing                | MCP server not starting                           | Run `npx @smartbear/mcp@latest` in a terminal to see startup errors            |
+| AI tools return `401`              | Missing PactFlow AI entitlement                   | Call `contract-testing_check_pactflow_ai_entitlements` to diagnose             |
+| can-i-deploy fails unexpectedly    | Provider never verified deployed consumer version | Add `{ deployedOrReleased: true }` to provider's `consumerVersionSelectors`    |
+| Verification results not appearing | Results published outside CI                      | `publishVerificationResults` should be `true` only when `CI=true`              |
+| Webhook not firing                 | Event type mismatch                               | Use `contract_requiring_verification_published` for triggering provider builds |

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -375,6 +375,10 @@
       "recipes/cypress",
       "recipes/munit",
       "implementation_guides/feature_toggles"
+    ],
+    "AI Tools": [
+      "ai_tools/pactflow-skill",
+      "ai_tools/smartbear-mcp"
     ]
   },
   "pact_broker": {

--- a/website/static/llms.txt
+++ b/website/static/llms.txt
@@ -38,6 +38,11 @@
 
 - [5 minute guide](/5-minute-getting-started-guide.md): From zero to running Pact tests in 5 mins
 
+## ai_tools
+
+- [PactFlow AI Assistant Skill](/ai_tools/pactflow-skill.md): The PactFlow skill turns your AI coding assistant into a PactFlow and Pact contract testing expert. It provides deep knowledge of consumer test patterns, provider verification configuration, can-i-deploy diagnostics, and full workspace management — surfaced directly in your editor without leaving your flow.
+- [SmartBear MCP Server](/ai_tools/smartbear-mcp.md): The @smartbear/mcp package is a Model Context Protocol server that exposes your PactFlow or Pact Broker workspace as a set of contract-testing_* tools. When configured alongside the PactFlow skill, your AI assistant gains structured, programmatic access to your workspace — direct matrix queries, AI-assisted test generation and review using your live provider states, BDCT cross-contract verification results, and full management of every broker resource.
+
 ## blogs_videos_and_articles
 
 - [Community videos and articles](/blogs_videos_and_articles.md): Check out the official Pact blog at docs.pact.io/blog and the PactFlow blog for blogs written by Pact maintainers.


### PR DESCRIPTION
Added docs for the new pactflow skill added to https://github.com/pactflow/pactflow-agent-skills

Changes were tested via running `yarn start` from the website folder