### PR TITLE
chore: upgrade node in github actions pipeline

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -142,7 +142,7 @@ jobs:
 
     - uses: actions/setup-node@v2
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Build
       run: scripts/build.sh

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -142,7 +142,7 @@ jobs:
 
     - uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '20'
 
     - name: Build
       run: scripts/build.sh


### PR DESCRIPTION
While upgrading the node version previously for docusaurus upgrade(https://github.com/pact-foundation/docs.pact.io/pull/409), the node version wasn't updated in the build scripts triggered for docs sync resulting in those pipelines breaking.