### PR TITLE
docs(telemetry): rewrite for Scarf + embed ecosystem pixel in README (PACT-7009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 * [Pact Foundation Slack workspace](https://slack.pact.io)
 * [Twitter](https://twitter.com/pact_up)
+
+## Anonymized analytics
+
+This repository's README is instrumented with a [Scarf](https://scarf.sh/) pixel that records anonymized README impressions on github.com so Pact OSS maintainers can see how the docs site is discovered. No personal information, IP addresses, cookies, or persistent identifiers are collected. See [docs.pact.io/telemetry](https://docs.pact.io/telemetry) for the full disclosure and opt-out options.
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4eb08b9f-98b1-4f94-9f0b-47f793362c8a&page=README.md" />

--- a/website/docs/telemetry.md
+++ b/website/docs/telemetry.md
@@ -4,21 +4,44 @@ title: Telemetry
 
 The Pact team strive to develop great open source tools for the community. We rely on the community's input to help us iterate on and improve Pact. Telemetry is additional information that helps us to better understand the community's needs, diagnose issues, and prioritise feature work.
 
-The Pact client libraries (e.g. Pact JS, Pact JVM) collect telemetry, such as generic usage metrics and system and environment information. For details of the types of telemetry collected, see [Types of information collected](#types-of-information-collected).
+Pact's distribution channels — Docker images on Docker Hub, CLI binaries on GitHub Releases, and similar — are routed through [Scarf](https://scarf.sh/), which collects anonymized usage analytics about how Pact tools are downloaded. README impressions on github.com and Docker Hub are also tracked via 1x1 pixel images served from `static.scarf.sh`.
 
-We do not collect personal information, such as usernames or email addresses. It also does not extract sensitive project-level information.
+We do not collect personal information, such as usernames or email addresses. Pact tools do not extract sensitive project-level information at runtime.
 
-When using Pact you can control whether telemetry is enabled, and the setting can be changed at any point in time. If telemetry remains enabled, telemetry data is sent in the background without requiring any additional customer interaction.
+When consuming Pact tools you can control whether telemetry is enabled, and the setting can be changed at any point in time. If telemetry remains enabled, telemetry data is sent in the background without requiring any additional interaction.
 
-This data is collected via [Google Analytics (GA)](https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide) and is accessible by Pact OSS maintainers.
+This data is collected via [Scarf](https://scarf.sh/) and is accessible by Pact OSS maintainers.
 
 ## Opt Out
 
-### Disabling telemetry for a session
+Scarf collects analytics at the moment you pull / download a Pact distribution. The primary opt-out is **to use the canonical (Docker Hub / GitHub Releases / etc.) URLs directly instead of the Pact Foundation's Scarf gateway URLs documented in each project's README.**
 
-To disable telemetry for your current session, you must set the environment variable `PACT_DO_NOT_TRACK` to `true`. You must repeat the command for each new terminal or session.
+### Docker images
 
-In macOS and Linux operating systems, you can disable telemetry for a single session as follows:
+To opt out of pull-event analytics for the Pact Broker (and any other Pact Docker image), pull from Docker Hub directly:
+
+```bash
+docker pull pactfoundation/pact-broker
+```
+
+Avoid the `docker.pactflow.io/pactfoundation/...` gateway URLs shown in each project's README install / examples blocks.
+
+### CLI binaries
+
+To opt out of download-event analytics for Pact CLI binaries (e.g. `pact-broker-cli`, `pact-cli`), download from the canonical [GitHub Releases](https://github.com/pact-foundation/pact-broker-cli/releases) page directly. Avoid the Scarf gateway URLs documented in each tool's README (e.g. `curl <gateway>/...installer.sh | sh`).
+
+### README impression pixel
+
+A 1x1 image served from `static.scarf.sh` records README impressions on github.com and Docker Hub. To opt out:
+
+- Disable image loading in your browser when viewing the README; or
+- Block `static.scarf.sh` at the network level (firewall, DNS sinkhole, browser content-blocker).
+
+### `PACT_DO_NOT_TRACK` for install scripts
+
+Some Pact install scripts (e.g. the `pact-cli` installer) respect the `PACT_DO_NOT_TRACK` environment variable as a fail-fast opt-out for install-time analytics events. Where this is supported, setting `PACT_DO_NOT_TRACK=true` prevents the script from emitting any telemetry.
+
+In macOS and Linux operating systems:
 
 ```bash
 export PACT_DO_NOT_TRACK=true
@@ -30,7 +53,8 @@ On Windows (PowerShell):
 $env:PACT_DO_NOT_TRACK = 'true'
 ```
 
-Maven pom.xml>surefire :
+Maven `pom.xml` > `surefire`:
+
 ```xml
 <property>
     <name>pact_do_not_track</name>
@@ -40,9 +64,9 @@ Maven pom.xml>surefire :
 
 ### Disabling telemetry for your profile in all sessions
 
-To disable telemetry permanenently (for all future sessions), you need to add a new item to your list of permanent environment variables.
+To disable install-time analytics permanently for every future session, add `PACT_DO_NOT_TRACK=true` to your permanent environment variables.
 
-In macOS and Linux operating systems, you can add it to your terminal profile as follows:
+In macOS and Linux operating systems, add it to your shell profile:
 
 ```bash
 echo "export PACT_DO_NOT_TRACK=true" >> ~/.profile
@@ -56,28 +80,35 @@ setx PACT_DO_NOT_TRACK "true"
 refresh env
 ```
 
+This affects install-time scripts that honor `PACT_DO_NOT_TRACK`. Scarf gateway analytics for pulls and downloads are opted out **by URL** (see above sections), not by environment variable, and the README impression pixel is opted out via image / network blocking.
+
 ## Types of Information Collected
 
-The information collected is a combination of data about the the environment and event occurring and parameters required by GA.
+Telemetry collected through [Scarf](https://scarf.sh/) falls into three categories, per [Scarf's Docker / File Packages documentation](https://docs.scarf.sh/packages/):
 
-| Data                        | Description                                                                                             |
-| :-------------------------- | :------------------------------------------------------------------------------------------------------ |
-| Version of API              | Version of the GA API used to collect telemetry                                                         |
-| Hash of hostname            | MD5 digest hash of the hostname. Used to anonymously detect repeat usage                                |
-| Human readable library name | Human readable string to indicate which library generated the event e.g 'Pact JS'                       |
-| Library name                | The name of the library as it appears in github e.g 'pact-js'                                           |
-| Library version             | The semantic version of the Library that generated the event e.g v1.2.3                                 |
-| AIP                         | Anonymised IP address of the computer                                                                   |
-| Data Source                 | Environment where the code generating the event ran, e.g 'cli', 'client' or 'broker'                    |
-| OS and Arch                 | The OS and Arch of the machine that generated the event e.g 'linux-x86_64'                              |
-| Plugin name                 | Where the event is generated from a plugin, the name of that plugin                                     |
-| Plugin version              | Where the event is generated from a plugin, the version of that plugin                                  |
-| Pact verification mode      | The language or test framework running the pact test that generated the event e.g 'Ruby', 'JUnit'       |
-| Platform version            | The version related to the above test framework or language                                             |
-| Event                       | Human readable string to indicate which event occurred e.g 'Pacts verified'                             |
-| Category                    | Used to determine if the test running was a provider test of consumer test                              |
-| Action                      | Used to indicate an action that occurred in the code when the event was generated.                      |
-| Value                       | Numerical value that can be used to track any number related to the event, e.g number of pacts verified |
+| Category | Description |
+| :-- | :-- |
+| System and OS statistics | Parsed from the client `User-Agent` header: Docker client version, language runtime, kernel version, OS (`linux` / `darwin` / `windows`), architecture (`amd64` / `arm64` / `arm`). |
+| Company information | Organisation / company name derived from the source IP via an ASN lookup at request time. Attributes usage at company level, not user level. |
+| Downloads by versions / tags | The tag in a Docker pull, or the version in a release download. Tells maintainers which versions are in active use. |
+
+Additional metadata per Scarf's [privacy policy](https://about.scarf.sh/privacy-policy):
+
+| Category | Description |
+| :-- | :-- |
+| Coarse-grained location | Country, derived from the source IP at request time. |
+| Referring URL | For README pixel impressions, the page that referred the request, when present. |
+| Page parameter | For README pixel impressions, the page name passed in the pixel URL (always `README.md` for Pact's pixels). |
+| Pixel ID | The `x-pxid` query parameter identifying which pixel fired the event. |
+
+### What is NOT collected
+
+Per Scarf's documentation:
+
+- **IP addresses are not stored.** They are used at request time for the geo / organisation lookup and then discarded.
+- **No cookies are set.**
+- **No persistent identifiers are used.** Users are not tracked across sessions or across sites.
+- **No personally identifiable information is retained.**
 
 ## Further Questions?
 

--- a/website/docs/telemetry.md
+++ b/website/docs/telemetry.md
@@ -14,7 +14,7 @@ This data is collected via [Scarf](https://scarf.sh/) and is accessible to Smart
 
 ## Opt Out
 
-Scarf collects analytics at the moment you pull / download a Pact distribution. The primary opt-out is **to use the canonical (Docker Hub / GitHub Releases / etc.) URLs directly instead of the Pact Foundation's Scarf gateway URLs documented in each project's README.**
+Scarf collects analytics at the moment you install or download a Pact distribution. The primary opt-out is **to use the canonical (Docker Hub / GitHub Releases / etc.) URLs directly instead of the Pact Foundation's Scarf gateway URLs documented in each project's README.**
 
 ### Docker images
 

--- a/website/docs/telemetry.md
+++ b/website/docs/telemetry.md
@@ -10,7 +10,7 @@ We do not collect personal information, such as usernames or email addresses. Pa
 
 When consuming Pact tools you can control whether telemetry is enabled, and the setting can be changed at any point in time. If telemetry remains enabled, telemetry data is sent in the background without requiring any additional interaction.
 
-This data is collected via [Scarf](https://scarf.sh/) and is accessible by Pact OSS maintainers.
+This data is collected via [Scarf](https://scarf.sh/) and is accessible to SmartBear.
 
 ## Opt Out
 


### PR DESCRIPTION
## Summary

- Replaces `website/docs/telemetry.md` (legacy Google Analytics description) with the Scarf-based telemetry model: Package gateways for pulls/downloads, README pixel impressions, URL-based opt-out, `PACT_DO_NOT_TRACK` scoped to install scripts, refreshed "Types of Information Collected" table per [docs.scarf.sh/packages/](https://docs.scarf.sh/packages/) and [Scarf's privacy policy](https://about.scarf.sh/privacy-policy).
- Adds a new "Anonymized analytics" section to the repo-level `README.md` and embeds the Pact ecosystem Scarf pixel (`4eb08b9f-98b1-4f94-9f0b-47f793362c8a`) so docs.pact.io README impressions on github.com land on the same Scarf dashboard as the other instrumented repos.

Jira: [PACT-7009](https://smartbear.atlassian.net/browse/PACT-7009). Parent epic: [PACT-6977](https://smartbear.atlassian.net/browse/PACT-6977). Siblings: PACT-6978 (broker), PACT-7007 (cli, shares the same pixel).

## Reviewer notes — please do not "tidy" the README snippet

The pixel snippet in `README.md` must stay HTML (not markdown `![]()`) and must keep both attributes intact:

\`\`\`html
<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=4eb08b9f-98b1-4f94-9f0b-47f793362c8a&page=README.md" />
\`\`\`

Per [Scarf's GitHub obfuscation note](https://docs.scarf.sh/web-traffic/#obfuscation-on-github), GitHub's `camo.githubusercontent.com` proxy strips the referrer and rewrites the URL. Dropping `referrerpolicy="no-referrer-when-downgrade"` or `&page=README.md`, or switching to markdown image syntax, silently undercounts impressions.

## Known follow-ups (not in this PR)

Two residual Google Analytics references live in **synced** doc trees (`custom_edit_url` set) and would be overwritten on the next sync — they need upstream fixes:

- `website/docs/implementation_guides/pact_plugins/docs/plugin-driver-design.md:236` — describes a GA event on plugin load. Fix upstream in `pact-foundation/pact-plugins`.
- `website/docs/implementation_guides/jvm/docs/system-properties.md:26` — `pact_do_not_track` row says "sent to Google Analytics". Fix upstream in `pact-foundation/pact-jvm`.

## Test plan

- [ ] Netlify preview deploys cleanly.
- [ ] On the preview, `/telemetry` renders with both tables, all code fences, and all links resolve (`scarf.sh`, `docs.scarf.sh/packages/`, `about.scarf.sh/privacy-policy`, `docs.pact.io/help/`).
- [ ] Sidebar entry for the Telemetry page still surfaces under the same node.
- [ ] On this PR's branch on github.com, the rendered `README.md` issues a `200` request to `camo.githubusercontent.com/...` for the Scarf pixel (network panel) — confirms camo passes the obfuscated pixel URL through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)